### PR TITLE
chore: activate manifest-based release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,4 +16,3 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: rust


### PR DESCRIPTION
Removing the `release-type` option should force the release-please to use configuration files instead.