### PR TITLE
feat: implement PDF header; `Document::write` method

### DIFF
--- a/pdfgen/src/lib.rs
+++ b/pdfgen/src/lib.rs
@@ -1,23 +1,31 @@
-pub mod object;
-pub mod types;
+#![forbid(unsafe_code)]
 
-pub enum PdfVersion {
-    V2,
-}
+//! `pdfgen` is a low-level library that offers fine-grained control over PDF syntax and
+//! PDF file generation.
 
+use std::io::{self, Write};
+
+mod object;
+mod types;
+
+/// This represents one cohesive PDF document that can contain multiple pages of content.
 #[derive(Default)]
-pub struct Document {}
+pub struct Document;
 
 impl Document {
-    pub fn new() -> Self {
-        Self {}
+    /// The PDF file begins with the 5 characters “%PDF–X.X” and byte offsets shall be calculated
+    /// from the PERCENT SIGN.
+    const PDF_HEADER: &[u8] = b"%PDF-2.0";
+
+    /// Write the PDF header and return number of written bytes.
+    fn write_header(&self, writer: &mut impl Write) -> Result<usize, io::Error> {
+        writer.write(Self::PDF_HEADER)
     }
 
-    fn _x(&self) {
-        let _x = 42 + 44;
-        match 42 {
-            0..50 => println!("Hurray! We're in range 0..50"),
-            _ => println!("Unfortunately, we aren't in the rage 0..50"),
-        }
+    /// Write the PDF contents into the provided writer.
+    pub fn write(&self, writer: &mut impl Write) -> Result<(), io::Error> {
+        let _bytes_written = self.write_header(writer)?;
+
+        Ok(())
     }
 }

--- a/pdfgen/src/lib.rs
+++ b/pdfgen/src/lib.rs
@@ -5,9 +5,6 @@
 
 use std::io::{self, Write};
 
-mod object;
-mod types;
-
 /// This represents one cohesive PDF document that can contain multiple pages of content.
 #[derive(Default)]
 pub struct Document;


### PR DESCRIPTION
This implements the basic `Document::write` function which writes PDF contents (as bytes) into a writer. Also a PDF-header is implemented, for now hard coded as constant (%PDF-2.0) as we will support only one PDF version for the time being.

Fixes #5.