### PR TITLE
feat: implement `PageTree` PDF object

### DIFF
--- a/pdfgen/src/types/hierarchy/array.rs
+++ b/pdfgen/src/types/hierarchy/array.rs
@@ -1,2 +1,0 @@
-/// Array object.
-pub struct Array;

--- a/pdfgen/src/types/hierarchy/mod.rs
+++ b/pdfgen/src/types/hierarchy/mod.rs
@@ -12,4 +12,5 @@
 
 pub mod cross_reference_table;
 pub mod page;
+pub mod page_tree;
 pub mod primitives;

--- a/pdfgen/src/types/hierarchy/page_tree.rs
+++ b/pdfgen/src/types/hierarchy/page_tree.rs
@@ -60,10 +60,10 @@ impl Object for PageTree {
             };
         }
 
-        let indent = b"       ".len();
+        let indent_level = Self::KIDS.len() + constants::SP.len();
         written += types::write_chain! {
             Self::KIDS.write(writer),
-            self.kids.write_array(writer, Some(indent)),
+            self.kids.write_array(writer, Some(indent_level)),
             writer.write(constants::NL_MARKER),
 
             Self::COUNT.write(writer),
@@ -112,8 +112,8 @@ mod tests {
 
         insta::assert_snapshot!(output, @r#"
         << /Type /Pages 
-        /Kids [0 0 R 
-               1 0 R 
+        /Kids [0 0 R
+               1 0 R
                2 0 R]
         /Count 0 >>
         "#);

--- a/pdfgen/src/types/hierarchy/page_tree.rs
+++ b/pdfgen/src/types/hierarchy/page_tree.rs
@@ -1,0 +1,121 @@
+use crate::types::{self, constants, hierarchy::primitives::name::Name};
+
+use super::primitives::{array::WriteArray, obj_ref::ObjRef, object::Object};
+
+/// Page tree is a structure which defines the ordering of pages in the document. The tree contains
+/// nodes of two types:
+///
+/// * intermediate nodes, which are [`PageTree`] nodes
+/// * leaf nodes, which are [`Page`] objects.
+///
+/// The simplest structure can consist of a single page tree node that references all of the
+/// document’s page objects directly. However, to optimise application performance, a PDF writer
+/// can construct trees of a particular form, known as balanced trees.
+///
+/// [`Page`]: super::page::Page
+#[derive(Debug, Default, Clone)]
+pub struct PageTree {
+    /// The page tree node that is the immediate parent of this one. Required for all nodes except
+    /// the root node.
+    parent: Option<ObjRef>,
+
+    /// An array of indirect references to the immediate children of this node. The children shall
+    /// only be [`Page`] objects or other [`PageTree`] nodes.
+    ///
+    /// [`Page`]: super::page::Page
+    kids: Vec<ObjRef>,
+
+    /// The number of leaf nodes ([`Page`] objects) that are descendants of this node within the
+    /// [`PageTree`]
+    ///
+    /// [`Page`]: super::page::Page
+    count: usize,
+}
+
+impl PageTree {
+    const PARENT: Name = Name::new(b"Parent");
+    const PAGES_TYPE: Name = Name::new(b"Pages");
+    const KIDS: Name = Name::new(b"Kids");
+    const COUNT: Name = Name::new(b"Count");
+
+    pub fn add_page(&mut self, page: ObjRef) {
+        self.kids.push(page);
+    }
+}
+
+impl Object for PageTree {
+    fn write(&self, writer: &mut impl std::io::Write) -> Result<usize, std::io::Error> {
+        let mut written = types::write_chain! {
+            writer.write(b"<< "),
+            Name::TYPE.write(writer),
+            Self::PAGES_TYPE.write(writer),
+            writer.write(constants::NL_MARKER),
+        };
+
+        if let Some(parent) = &self.parent {
+            written += types::write_chain! {
+                Self::PARENT.write(writer),
+                parent.write_ref(writer),
+                writer.write(constants::NL_MARKER),
+            };
+        }
+
+        let indent = b"       ".len();
+        written += types::write_chain! {
+            Self::KIDS.write(writer),
+            self.kids.write_array(writer, Some(indent)),
+            writer.write(constants::NL_MARKER),
+
+            Self::COUNT.write(writer),
+            writer.write(self.count.to_string().as_bytes()),
+            writer.write(b" >>"),
+        };
+
+        Ok(written)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::hierarchy::primitives::{obj_ref::ObjRef, object::Object};
+
+    use super::PageTree;
+
+    #[test]
+    fn simple_page_tree() {
+        let page_tree = PageTree::default();
+
+        let mut writer = Vec::new();
+        page_tree.write(&mut writer).unwrap();
+
+        let output = String::from_utf8(writer).unwrap();
+
+        insta::assert_snapshot!(output, @r#"
+        << /Type /Pages 
+        /Kids []
+        /Count 0 >>
+        "#);
+    }
+
+    #[test]
+    fn page_tree_with_kids() {
+        let mut page_tree = PageTree::default();
+
+        page_tree.add_page(ObjRef::from(0));
+        page_tree.add_page(ObjRef::from(1));
+        page_tree.add_page(ObjRef::from(2));
+
+        let mut writer = Vec::new();
+        page_tree.write(&mut writer).unwrap();
+
+        let output = String::from_utf8(writer).unwrap();
+
+        insta::assert_snapshot!(output, @r#"
+        << /Type /Pages 
+        /Kids [0 0 R 
+               1 0 R 
+               2 0 R]
+        /Count 0 >>
+        "#);
+    }
+}

--- a/pdfgen/src/types/hierarchy/primitives/array.rs
+++ b/pdfgen/src/types/hierarchy/primitives/array.rs
@@ -13,8 +13,10 @@ pub trait WriteArray {
 
 impl WriteArray for Vec<ObjRef> {
     fn write_array(&self, writer: &mut impl Write, indent: Option<usize>) -> Result<usize, Error> {
-        let mut written = writer.write(b"[")?;
-        let indent = " ".repeat(indent.unwrap_or(0));
+        let opening = b"[";
+
+        let mut written = writer.write(opening)?;
+        let indent = " ".repeat(indent.unwrap_or(0) + opening.len());
 
         for (idx, obj_ref) in self.iter().enumerate() {
             if idx > 0 {

--- a/pdfgen/src/types/hierarchy/primitives/array.rs
+++ b/pdfgen/src/types/hierarchy/primitives/array.rs
@@ -1,0 +1,30 @@
+use std::io::{Error, Write};
+
+use crate::types::constants;
+
+use super::obj_ref::ObjRef;
+
+pub trait WriteArray {
+    fn write_array(&self, writer: &mut impl Write, indent: Option<usize>) -> Result<usize, Error>;
+}
+
+impl WriteArray for Vec<ObjRef> {
+    fn write_array(&self, writer: &mut impl Write, indent: Option<usize>) -> Result<usize, Error> {
+        let mut written = writer.write(b"[")?;
+        let indent = " ".repeat(indent.unwrap_or(0));
+
+        for (idx, obj_ref) in self.iter().enumerate() {
+            if idx > 0 {
+                written += writer.write(constants::SP)?;
+                written += writer.write(constants::NL_MARKER)?;
+                written += writer.write(indent.as_bytes())?;
+            }
+
+            written += obj_ref.write_ref(writer)?;
+        }
+
+        written += writer.write(b"]")?;
+
+        Ok(written)
+    }
+}

--- a/pdfgen/src/types/hierarchy/primitives/array.rs
+++ b/pdfgen/src/types/hierarchy/primitives/array.rs
@@ -18,7 +18,6 @@ impl WriteArray for Vec<ObjRef> {
 
         for (idx, obj_ref) in self.iter().enumerate() {
             if idx > 0 {
-                written += writer.write(constants::SP)?;
                 written += writer.write(constants::NL_MARKER)?;
                 written += writer.write(indent.as_bytes())?;
             }

--- a/pdfgen/src/types/hierarchy/primitives/array.rs
+++ b/pdfgen/src/types/hierarchy/primitives/array.rs
@@ -4,7 +4,10 @@ use crate::types::constants;
 
 use super::obj_ref::ObjRef;
 
+/// Extension trait for implementations of arrays. This trait should be implemented for array-like
+/// data structures that can be used to represent PDF's array primitive type.
 pub trait WriteArray {
+    /// Encode `self` as PDF array and write it to the given implementor of [`Write`] trait.
     fn write_array(&self, writer: &mut impl Write, indent: Option<usize>) -> Result<usize, Error>;
 }
 

--- a/pdfgen/src/types/hierarchy/primitives/mod.rs
+++ b/pdfgen/src/types/hierarchy/primitives/mod.rs
@@ -1,6 +1,7 @@
 //! Definition and implementation of primitive PDF data types. These types are mostly used as
 //! values for various entries in object dictionaries (such as Page Tree and Page).
 
+pub mod array;
 pub mod name;
 pub mod obj_ref;
 pub mod object;

--- a/pdfgen/src/types/hierarchy/primitives/name.rs
+++ b/pdfgen/src/types/hierarchy/primitives/name.rs
@@ -57,6 +57,20 @@ impl Name {
         written += writer.write(b" ")?;
         Ok(written)
     }
+
+    /// The number of bytes that this `Name` occupies when written into the PDF document. This does
+    /// not include the whitespace written after the `Name`.
+    ///
+    /// # Example:
+    ///
+    /// ```ignore
+    /// let name = Name::new(b"Name");
+    /// // '/Name' has length of 5 bytes.
+    /// assert_eq!(name.len(), 5); //
+    /// ```
+    pub(crate) const fn len(&self) -> usize {
+        self.0.len() + 1
+    }
 }
 
 impl WriteDictValue for Name {

--- a/pdfgen/src/types/hierarchy/primitives/obj_ref.rs
+++ b/pdfgen/src/types/hierarchy/primitives/obj_ref.rs
@@ -10,6 +10,7 @@ use crate::types;
 /// object number, the generation number, and the keyword R (with whitespace separating each part).
 ///
 /// Example: `4 0 R`
+#[derive(Debug, Clone)]
 pub struct ObjRef {
     /// Identifier of referenced object.
     id: u64,

--- a/pdfgen/src/types/mod.rs
+++ b/pdfgen/src/types/mod.rs
@@ -15,6 +15,9 @@ pub trait WriteDictValue {
 pub mod constants {
     /// New line constant
     pub const NL_MARKER: &[u8] = b"\n";
+
+    /// Single Space
+    pub const SP: &[u8] = b" ";
 }
 
 /// Helper macro for counting the number of written bytes in multiple consecutive writes, where

--- a/pdfgen/src/types/mod.rs
+++ b/pdfgen/src/types/mod.rs
@@ -8,6 +8,15 @@ pub trait WriteDictValue {
     fn write(&self, writer: &mut impl Write) -> Result<usize, Error>;
 }
 
+/// Common constants used when writing encoded PDF into a [`Write`] or [`PdfWriter`].
+///
+/// [`Write`]: std::io::Write
+/// [`PdfWriter`]: super::pdf_writer::PdfWriter
+pub mod constants {
+    /// New line constant
+    pub const NL_MARKER: &[u8] = b"\n";
+}
+
 /// Helper macro for counting the number of written bytes in multiple consecutive writes, where
 /// each write returns a `Result<usize, std::io::Error>`
 ///

--- a/pdfgen/src/types/pdf_writer.rs
+++ b/pdfgen/src/types/pdf_writer.rs
@@ -3,8 +3,8 @@
 use super::{
     constants,
     hierarchy::{
-    cross_reference_table::CrossReferenceTable,
-    primitives::{obj_ref::ObjRef, object::Object},
+        cross_reference_table::CrossReferenceTable,
+        primitives::{obj_ref::ObjRef, object::Object},
     },
 };
 use std::io::{self, Write};

--- a/pdfgen/src/types/pdf_writer.rs
+++ b/pdfgen/src/types/pdf_writer.rs
@@ -1,8 +1,11 @@
 //! Implementation of the [`PdfWriter`] wrapper.
 
-use super::hierarchy::{
+use super::{
+    constants,
+    hierarchy::{
     cross_reference_table::CrossReferenceTable,
     primitives::{obj_ref::ObjRef, object::Object},
+    },
 };
 use std::io::{self, Write};
 
@@ -24,8 +27,6 @@ impl<W: Write> PdfWriter<W> {
     const PDF_HEADER: &[u8] = b"%PDF-2.0";
     /// The last line of the file shall contain only the end-of-file marker, %%EOF
     const EOF_MARKER: &[u8] = b"%%EOF";
-    /// New line constant
-    const NL_MARKER: &[u8] = b"\n";
     /// Marker indicating end of an object section
     const END_OBJ_MARKER: &[u8] = b"endobj";
 
@@ -44,7 +45,7 @@ impl<W: Write> PdfWriter<W> {
         // Delegate the actual writing to the inner writer incrementing the current_offset to
         // reflect current `cursor` position.
         self.current_offset += self.inner.write(Self::PDF_HEADER)?;
-        self.current_offset += self.inner.write(Self::NL_MARKER)?;
+        self.current_offset += self.inner.write(constants::NL_MARKER)?;
 
         Ok(())
     }
@@ -58,15 +59,15 @@ impl<W: Write> PdfWriter<W> {
 
         // X Y obj\n
         self.current_offset += obj_ref.write_def(&mut self.inner)?;
-        self.current_offset += self.inner.write(Self::NL_MARKER)?;
+        self.current_offset += self.inner.write(constants::NL_MARKER)?;
 
         // Delegate the actual writing to the inner writer.
         self.current_offset += obj.write(&mut self.inner)?;
-        self.current_offset += self.inner.write(Self::NL_MARKER)?;
+        self.current_offset += self.inner.write(constants::NL_MARKER)?;
 
         // endobj\n
         self.current_offset += self.inner.write(Self::END_OBJ_MARKER)?;
-        self.current_offset += self.inner.write(Self::NL_MARKER)?;
+        self.current_offset += self.inner.write(constants::NL_MARKER)?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR adds basic implementation of the `PageTree` hierarchical PDF object.

Closes #7 