### PR TITLE
feat: implement `Catalog` and PDF generation flow

### DIFF
--- a/pdfgen/src/lib.rs
+++ b/pdfgen/src/lib.rs
@@ -13,7 +13,14 @@ pub mod types;
 
 /// This represents one cohesive PDF document that can contain multiple pages of content.
 pub struct Document {
+    /// The [`Catalog`] PDF object that is the root of the document's object hierarchy.
     catalog: Catalog,
+
+    /// [`IdManager`] is tasked with creation of new [`ObjId`]s. This is the single source of truth
+    /// regarding [`ObjId`]s, ensuring that every [`ObjId`] is unique.
+    ///
+    /// [`ObjId`]: types::hierarchy::primitives::obj_id::ObjId
+    #[allow(dead_code)]
     id_manager: IdManager,
 }
 

--- a/pdfgen/src/lib.rs
+++ b/pdfgen/src/lib.rs
@@ -4,23 +4,79 @@
 //! PDF file generation.
 
 use std::io::{self, Write};
-use types::pdf_writer::PdfWriter;
+use types::{
+    hierarchy::{catalog::Catalog, page_tree::PageTree, primitives::obj_id::IdManager},
+    pdf_writer::PdfWriter,
+};
 
 pub mod types;
 
 /// This represents one cohesive PDF document that can contain multiple pages of content.
-#[derive(Default)]
-pub struct Document;
+pub struct Document {
+    catalog: Catalog,
+    id_manager: IdManager,
+}
+
+impl Default for Document {
+    fn default() -> Self {
+        let mut id_manager = IdManager::default();
+        let catalog_id = id_manager.create_id();
+        let page_tree_root_id = id_manager.create_id();
+        let root_page_tree = PageTree::new(page_tree_root_id, None);
+        let catalog = Catalog::new(catalog_id, root_page_tree);
+
+        Self {
+            catalog,
+            id_manager,
+        }
+    }
+}
 
 impl Document {
     /// Write the PDF contents into the provided writer.
     pub fn write(&self, writer: &mut impl Write) -> Result<(), io::Error> {
         let mut pdf_writer = PdfWriter::new(writer);
         pdf_writer.write_header()?;
-        // Write object(s) here!
+
+        pdf_writer.write_object(&self.catalog, self.catalog.obj_ref())?;
+        pdf_writer.write_object(self.catalog.page_tree(), self.catalog.page_tree().obj_ref())?;
+
         pdf_writer.write_crt()?;
         pdf_writer.write_eof()?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Document;
+
+    #[test]
+    fn simple_document() {
+        let document = Document::default();
+
+        let mut writer = Vec::default();
+        document.write(&mut writer).unwrap();
+
+        let output = String::from_utf8(writer).unwrap();
+
+        insta::assert_snapshot!(output, @r#"
+        %PDF-2.0
+        0 0 obj
+        << /Type /Catalog 
+        /Pages 1 0 R >>
+        endobj
+        1 0 obj
+        << /Type /Pages 
+        /Kids []
+        /Count 0 >>
+        endobj
+        xref
+        0 2
+        0000000009 00000 n 
+        0000000059 00000 n 
+        %%EOF
+        "#);
     }
 }

--- a/pdfgen/src/types/hierarchy/catalog.rs
+++ b/pdfgen/src/types/hierarchy/catalog.rs
@@ -1,0 +1,58 @@
+use std::io::Error;
+
+use crate::types::{self, constants};
+
+use super::primitives::{name::Name, obj_ref::ObjRef, object::Object};
+
+pub struct Catalog {
+    root_page_tree: ObjRef,
+}
+
+impl Catalog {
+    const CATALOG: Name = Name::new(b"Catalog");
+    const PAGES: Name = Name::new(b"Pages");
+
+    pub(crate) fn new(root_page_tree: ObjRef) -> Self {
+        Self { root_page_tree }
+    }
+}
+
+impl Object for Catalog {
+    fn write(&self, writer: &mut impl std::io::Write) -> Result<usize, Error> {
+        let written = types::write_chain! {
+            writer.write(b"<< "),
+
+            Name::TYPE.write(writer),
+            Self::CATALOG.write(writer),
+            writer.write(constants::NL_MARKER),
+
+            Self::PAGES.write(writer),
+            self.root_page_tree.write_ref(writer),
+
+            writer.write(b" >>"),
+        };
+
+        Ok(written)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::hierarchy::primitives::{obj_ref::ObjRef, object::Object};
+
+    use super::Catalog;
+
+    #[test]
+    fn simple_catalog() {
+        let catalog = Catalog::new(ObjRef::from(10));
+
+        let mut writer = Vec::default();
+        catalog.write(&mut writer).unwrap();
+
+        let output = String::from_utf8(writer).unwrap();
+        insta::assert_snapshot!(output, @r#"
+        << /Type /Catalog 
+        /Pages 10 0 R >>
+        "#);
+    }
+}

--- a/pdfgen/src/types/hierarchy/catalog.rs
+++ b/pdfgen/src/types/hierarchy/catalog.rs
@@ -7,6 +7,14 @@ use super::{
     primitives::{name::Name, obj_id::ObjId, object::Object},
 };
 
+/// The root of a document’s object hierarchy, located by means of the `Root` entry in the trailer
+/// of the PDF file.
+///
+/// The catalog dictionary contains references to other objects defining the document’s contents,
+/// outline, article threads, named destinations, and other attributes. In addition, it contains
+/// information about how the document shall be displayed on the screen, such as whether its
+/// outline and thumbnail page images shall be displayed automatically and whether some location
+/// other than the first page shall be shown when the document is opened.
 pub struct Catalog {
     /// The object reference allocated to this `Catalog`.
     obj_ref: ObjId,
@@ -19,6 +27,7 @@ impl Catalog {
     const CATALOG: Name = Name::new(b"Catalog");
     const PAGES: Name = Name::new(b"Pages");
 
+    /// Create a new `Catalog` with the given [`ObjId`] and [`PageTree`].
     pub(crate) fn new(obj_ref: ObjId, root_page_tree: PageTree) -> Self {
         Self {
             obj_ref,
@@ -26,10 +35,12 @@ impl Catalog {
         }
     }
 
+    /// Returns the [`ObjId`] allocated to this `Catalog`.
     pub(crate) fn obj_ref(&self) -> ObjId {
         self.obj_ref.clone()
     }
 
+    /// Returns a reference to the root [`PageTree`] that this `Catalog` holds.
     pub(crate) fn page_tree(&self) -> &PageTree {
         &self.root_page_tree
     }

--- a/pdfgen/src/types/hierarchy/mod.rs
+++ b/pdfgen/src/types/hierarchy/mod.rs
@@ -10,6 +10,7 @@
 //!
 //! Reference: ISO 32000-2:2020 (PDF 2.0); page 114
 
+pub mod catalog;
 pub mod cross_reference_table;
 pub mod page;
 pub mod page_tree;

--- a/pdfgen/src/types/hierarchy/page.rs
+++ b/pdfgen/src/types/hierarchy/page.rs
@@ -3,14 +3,14 @@ use std::io::{Error, Write};
 use crate::types;
 
 use super::primitives::{
-    name::Name, obj_ref::ObjRef, object::Object, rectangle::Rectangle, resources::Resources,
+    name::Name, obj_id::ObjId, object::Object, rectangle::Rectangle, resources::Resources,
 };
 
 /// Page objects are the leaves of the page tree, each of which is a dictionary specifying the
 /// attributes of a single page of the document.
 pub struct Page {
     /// The page tree node that is the immediate parent of this page object.
-    parent: ObjRef,
+    parent: ObjId,
 
     /// A dictionary containing any resources required by the page contents. If the page requires
     /// no resources, the value of this entry shall be an empty dictionary.
@@ -28,9 +28,9 @@ impl Page {
     const MEDIA_BOX: Name = Name::new(b"MediaBox");
 
     /// Create a new blank page that belongs to the given parent and media box.
-    pub fn new(parent: impl Into<ObjRef>, media_box: impl Into<Rectangle>) -> Self {
+    pub fn new(parent: ObjId, media_box: impl Into<Rectangle>) -> Self {
         Self {
-            parent: parent.into(),
+            parent,
             resources: Resources::default(),
             media_box: media_box.into(),
         }
@@ -65,11 +65,12 @@ impl Object for Page {
 #[cfg(test)]
 mod tests {
     use super::Page;
-    use crate::types::hierarchy::primitives::object::Object;
+    use crate::types::hierarchy::primitives::{obj_id::IdManager, object::Object};
 
     #[test]
     fn basic_page() {
-        let page = Page::new(0, (0, 0, 100, 100));
+        let mut id_manager = IdManager::default();
+        let page = Page::new(id_manager.create_id(), (0, 0, 100, 100));
 
         let mut writer = Vec::new();
         page.write(&mut writer).unwrap();

--- a/pdfgen/src/types/hierarchy/page_tree.rs
+++ b/pdfgen/src/types/hierarchy/page_tree.rs
@@ -1,6 +1,6 @@
 use crate::types::{self, constants, hierarchy::primitives::name::Name};
 
-use super::primitives::{array::WriteArray, obj_ref::ObjRef, object::Object};
+use super::primitives::{array::WriteArray, obj_id::ObjId, object::Object};
 
 /// Page tree is a structure which defines the ordering of pages in the document. The tree contains
 /// nodes of two types:
@@ -13,17 +13,20 @@ use super::primitives::{array::WriteArray, obj_ref::ObjRef, object::Object};
 /// can construct trees of a particular form, known as balanced trees.
 ///
 /// [`Page`]: super::page::Page
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct PageTree {
+    /// The object reference allocated for this `PageTree`.
+    obj_id: ObjId,
+
     /// The page tree node that is the immediate parent of this one. Required for all nodes except
     /// the root node.
-    parent: Option<ObjRef>,
+    parent: Option<ObjId>,
 
     /// An array of indirect references to the immediate children of this node. The children shall
     /// only be [`Page`] objects or other [`PageTree`] nodes.
     ///
     /// [`Page`]: super::page::Page
-    kids: Vec<ObjRef>,
+    kids: Vec<ObjId>,
 
     /// The number of leaf nodes ([`Page`] objects) that are descendants of this node within the
     /// [`PageTree`]
@@ -38,8 +41,22 @@ impl PageTree {
     const KIDS: Name = Name::new(b"Kids");
     const COUNT: Name = Name::new(b"Count");
 
-    pub fn add_page(&mut self, page: ObjRef) {
+    pub fn new(obj_id: ObjId, parent: Option<&PageTree>) -> Self {
+        Self {
+            obj_id,
+            parent: parent.map(|parent| parent.obj_ref()),
+            kids: Vec::default(),
+            count: 0,
+        }
+    }
+
+    pub fn add_page(&mut self, page: ObjId) {
         self.kids.push(page);
+        self.count += 1;
+    }
+
+    pub fn obj_ref(&self) -> ObjId {
+        self.obj_id.clone()
     }
 }
 
@@ -77,13 +94,14 @@ impl Object for PageTree {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::hierarchy::primitives::{obj_ref::ObjRef, object::Object};
+    use crate::types::hierarchy::primitives::{obj_id::IdManager, object::Object};
 
     use super::PageTree;
 
     #[test]
     fn simple_page_tree() {
-        let page_tree = PageTree::default();
+        let mut id_manager = IdManager::default();
+        let page_tree = PageTree::new(id_manager.create_id(), None);
 
         let mut writer = Vec::new();
         page_tree.write(&mut writer).unwrap();
@@ -99,11 +117,12 @@ mod tests {
 
     #[test]
     fn page_tree_with_kids() {
-        let mut page_tree = PageTree::default();
+        let mut id_manager = IdManager::default();
+        let mut page_tree = PageTree::new(id_manager.create_id(), None);
 
-        page_tree.add_page(ObjRef::from(0));
-        page_tree.add_page(ObjRef::from(1));
-        page_tree.add_page(ObjRef::from(2));
+        page_tree.add_page(id_manager.create_id());
+        page_tree.add_page(id_manager.create_id());
+        page_tree.add_page(id_manager.create_id());
 
         let mut writer = Vec::new();
         page_tree.write(&mut writer).unwrap();
@@ -112,10 +131,10 @@ mod tests {
 
         insta::assert_snapshot!(output, @r#"
         << /Type /Pages 
-        /Kids [0 0 R
-               1 0 R
-               2 0 R]
-        /Count 0 >>
+        /Kids [1 0 R
+               2 0 R
+               3 0 R]
+        /Count 3 >>
         "#);
     }
 }

--- a/pdfgen/src/types/hierarchy/primitives/array.rs
+++ b/pdfgen/src/types/hierarchy/primitives/array.rs
@@ -2,7 +2,7 @@ use std::io::{Error, Write};
 
 use crate::types::constants;
 
-use super::obj_ref::ObjRef;
+use super::obj_id::ObjId;
 
 /// Extension trait for implementations of arrays. This trait should be implemented for array-like
 /// data structures that can be used to represent PDF's array primitive type.
@@ -11,7 +11,7 @@ pub trait WriteArray {
     fn write_array(&self, writer: &mut impl Write, indent: Option<usize>) -> Result<usize, Error>;
 }
 
-impl WriteArray for Vec<ObjRef> {
+impl WriteArray for Vec<ObjId> {
     fn write_array(&self, writer: &mut impl Write, indent: Option<usize>) -> Result<usize, Error> {
         let opening = b"[";
 

--- a/pdfgen/src/types/hierarchy/primitives/mod.rs
+++ b/pdfgen/src/types/hierarchy/primitives/mod.rs
@@ -3,7 +3,7 @@
 
 pub mod array;
 pub mod name;
-pub mod obj_ref;
+pub mod obj_id;
 pub mod object;
 pub mod rectangle;
 pub mod resources;

--- a/pdfgen/src/types/hierarchy/primitives/obj_id.rs
+++ b/pdfgen/src/types/hierarchy/primitives/obj_id.rs
@@ -11,18 +11,12 @@ use crate::types;
 ///
 /// Example: `4 0 R`
 #[derive(Debug, Clone)]
-pub struct ObjRef {
+pub struct ObjId {
     /// Identifier of referenced object.
     id: u64,
 }
 
-impl From<u64> for ObjRef {
-    fn from(id: u64) -> Self {
-        Self { id }
-    }
-}
-
-impl ObjRef {
+impl ObjId {
     /// Marker indicating start of an object section
     const START_OBJ_MARKER: &[u8] = b"obj";
 
@@ -49,5 +43,18 @@ impl ObjRef {
         };
 
         Ok(written)
+    }
+}
+
+#[derive(Default)]
+pub struct IdManager {
+    curr: u64,
+}
+
+impl IdManager {
+    pub fn create_id(&mut self) -> ObjId {
+        let inner_id = self.curr;
+        self.curr += 1;
+        ObjId { id: inner_id }
     }
 }

--- a/pdfgen/src/types/pdf_writer.rs
+++ b/pdfgen/src/types/pdf_writer.rs
@@ -4,7 +4,7 @@ use super::{
     constants,
     hierarchy::{
         cross_reference_table::CrossReferenceTable,
-        primitives::{obj_ref::ObjRef, object::Object},
+        primitives::{obj_id::ObjId, object::Object},
     },
 };
 use std::io::{self, Write};
@@ -53,7 +53,7 @@ impl<W: Write> PdfWriter<W> {
     /// Writes the object start marker(`X X obj`), following with the structured data of the object
     /// itself, finalizing with object end marker(`endobj`), ensuring correct CrossReferenceTable
     /// and cursor update.
-    pub fn write_object(&mut self, obj: &impl Object, obj_ref: ObjRef) -> Result<(), io::Error> {
+    pub fn write_object(&mut self, obj: &impl Object, obj_ref: ObjId) -> Result<(), io::Error> {
         // Save the objects byte offset in the CrossReferenceTable.
         self.cross_reference_table.add_object(self.current_offset);
 
@@ -89,7 +89,7 @@ impl<W: Write> PdfWriter<W> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{types::hierarchy::primitives::obj_ref::ObjRef, PdfWriter};
+    use crate::{types::hierarchy::primitives::obj_id::IdManager, PdfWriter};
 
     use super::Object;
 
@@ -134,19 +134,22 @@ mod tests {
     fn write_object() {
         let mut writer = Vec::new();
         let mut pdf_writer = PdfWriter::new(&mut writer);
+        let mut id_manager = IdManager::default();
 
-        pdf_writer.write_object(&Dummy, ObjRef::from(17)).unwrap();
+        pdf_writer
+            .write_object(&Dummy, id_manager.create_id())
+            .unwrap();
 
         let output = String::from_utf8(writer).unwrap();
 
         insta::assert_snapshot!(
             output,
-            @r"
-        17 0 obj
+            @r#"
+        0 0 obj
         FirstLine
         SecondLine
         endobj
-        "
+        "#
         );
     }
 
@@ -154,12 +157,21 @@ mod tests {
     fn write_crt() {
         let mut writer = Vec::new();
         let mut pdf_writer = PdfWriter::new(&mut writer);
+        let mut id_manager = IdManager::default();
 
         pdf_writer.write_header().unwrap();
-        pdf_writer.write_object(&Dummy, ObjRef::from(1)).unwrap();
-        pdf_writer.write_object(&Dummy, ObjRef::from(2)).unwrap();
-        pdf_writer.write_object(&Dummy, ObjRef::from(3)).unwrap();
-        pdf_writer.write_object(&Dummy, ObjRef::from(4)).unwrap();
+        pdf_writer
+            .write_object(&Dummy, id_manager.create_id())
+            .unwrap();
+        pdf_writer
+            .write_object(&Dummy, id_manager.create_id())
+            .unwrap();
+        pdf_writer
+            .write_object(&Dummy, id_manager.create_id())
+            .unwrap();
+        pdf_writer
+            .write_object(&Dummy, id_manager.create_id())
+            .unwrap();
         pdf_writer.write_crt().unwrap();
         pdf_writer.write_eof().unwrap();
 
@@ -167,8 +179,12 @@ mod tests {
 
         insta::assert_snapshot!(
             output,
-            @r"
+            @r#"
         %PDF-2.0
+        0 0 obj
+        FirstLine
+        SecondLine
+        endobj
         1 0 obj
         FirstLine
         SecondLine
@@ -181,10 +197,6 @@ mod tests {
         FirstLine
         SecondLine
         endobj
-        4 0 obj
-        FirstLine
-        SecondLine
-        endobj
         xref
         0 4
         0000000009 00000 n 
@@ -192,7 +204,7 @@ mod tests {
         0000000081 00000 n 
         0000000117 00000 n 
         %%EOF
-        "
+        "#
         );
     }
 }


### PR DESCRIPTION
In this PR we implement the `Catalog` PDF object. This is the piece that ties the whole document together. Basically, Catalog defines where the root page tree node is, and root page tree node holds the pages (and eventually other page trees). 

Because of this, the PDF generation flow is somewhat reworked in this PR as well. The `ObjRef` is renamed to `ObjId` as that carries the meaning better. There is now a single `IdManager` class that handles the generation of IDs. At the moment it's possible to create `IdManager` from anywhere using its `Default` implementation. We should think about how to restrict this, as it's probably better idea to let the `Document` handle IDs (to have a single source of truth for the IDs). 

Closes #6
Closes #12 