### PR TITLE
fix: re-use variable instead of direct env var check in snap macro

### DIFF
--- a/pdfgen/tests/macros/mod.rs
+++ b/pdfgen/tests/macros/mod.rs
@@ -63,7 +63,7 @@ macro_rules! snap_test {
                 String::from_utf8_lossy(&buf).into_owned()
             };
 
-            if std::env::var("PDFGEN_UPDATE_SNAPS").is_ok() {
+            if update_snaps {
                 file.write_all(&writer).unwrap();
             } else {
                 std::fs::remove_file(file_path).unwrap();


### PR DESCRIPTION
### What?
This is a minor fix, where instead of directly checking the value of env variable we simply reuse previous check.

### Why?
Changing the name of the env variable might lead to errors if we check it with hard-coded string multiple times. Single place of truth is better.

### Checklist
- [x] Tests are added/updated.
- [x] Documentation is added/updated.
- [x] Self-review of code changes completed.

### Related Issues
None
