### PR TITLE
fix: use absolute paths in `snap_test` macro

### DIFF
--- a/pdfgen/tests/gen_test.rs
+++ b/pdfgen/tests/gen_test.rs
@@ -1,8 +1,3 @@
-use std::{
-    io::{Read, Write},
-    path::PathBuf,
-};
-
 use pdfgen::{types::hierarchy::primitives::rectangle::Rectangle, Document};
 
 mod macros;

--- a/pdfgen/tests/macros/mod.rs
+++ b/pdfgen/tests/macros/mod.rs
@@ -2,13 +2,16 @@
 macro_rules! function_name {
     () => {{
         fn f() {}
+
         fn type_name_of_val<T>(_: T) -> &'static str {
-            std::any::type_name::<T>()
+            ::std::any::type_name::<T>()
         }
+
         let mut name = type_name_of_val(f).strip_suffix("::f").unwrap_or("");
-        while let Some(rest) = name.strip_suffix("::{{closure}}") {
+        while let ::std::option::Option::Some(rest) = name.strip_suffix("::{{closure}}") {
             name = rest;
         }
+
         name
     }};
 }
@@ -16,40 +19,42 @@ macro_rules! function_name {
 #[macro_export]
 macro_rules! snap_test {
     ($doc:ident) => {{
-        let crate_dir = env!("CARGO_MANIFEST_DIR");
-        let module_path = module_path!()
+        use ::std::io::{Read, Write};
+
+        let crate_dir = ::std::env!("CARGO_MANIFEST_DIR");
+        let module_path = ::std::module_path!()
             .strip_prefix("r#mod::")
             .unwrap_or(module_path!())
             .replace("::", "/");
 
-        let path = format!("{crate_dir}/tests/snapshots/{module_path}");
-        std::fs::create_dir_all(&path).unwrap();
+        let path = ::std::format!("{crate_dir}/tests/snapshots/{module_path}");
+        ::std::fs::create_dir_all(&path).unwrap();
 
         let function_name = macros::function_name!().split("::").last().unwrap();
-        let file_path = format!("{path}/{function_name}.pdf");
+        let file_path = ::std::format!("{path}/{function_name}.pdf");
 
-        let update_snaps = std::env::var("PDFGEN_UPDATE_SNAPS").is_ok_and(|val| val == "1");
+        let update_snaps = ::std::env::var("PDFGEN_UPDATE_SNAPS").is_ok_and(|val| val == "1");
 
-        let mut writer = Vec::default();
+        let mut writer = ::std::vec::Vec::default();
         $doc.write(&mut writer).unwrap();
 
-        let doc_content = String::from_utf8_lossy(&writer);
+        let doc_content = ::std::string::String::from_utf8_lossy(&writer);
 
-        if PathBuf::from(&file_path).is_file() {
-            let buf = std::fs::read(&file_path).unwrap();
-            let file_content = String::from_utf8_lossy(&buf);
+        if ::std::path::PathBuf::from(&file_path).is_file() {
+            let buf = ::std::fs::read(&file_path).unwrap();
+            let file_content = ::std::string::String::from_utf8_lossy(&buf);
 
             if update_snaps {
-                let cmp = pretty_assertions::StrComparison::new(&file_content, &doc_content);
-                eprintln!("Updating snapshot '{file_path}':\n{cmp}");
+                let cmp = ::pretty_assertions::StrComparison::new(&file_content, &doc_content);
+                ::std::eprintln!("Updating snapshot '{file_path}':\n{cmp}");
 
-                std::fs::write(&file_path, doc_content.as_bytes()).unwrap();
+                ::std::fs::write(&file_path, doc_content.as_bytes()).unwrap();
             } else {
-                pretty_assertions::assert_str_eq!(file_content, doc_content);
-                println!("To update snapshots, run tests again with 'cargo bless'")
+                ::pretty_assertions::assert_str_eq!(file_content, doc_content);
+                ::std::println!("To update snapshots, run tests again with 'cargo bless'")
             }
         } else {
-            let mut file = std::fs::OpenOptions::new()
+            let mut file = ::std::fs::OpenOptions::new()
                 .write(true) // read-write file
                 .read(true)
                 .create(true) // create if not existing
@@ -58,16 +63,16 @@ macro_rules! snap_test {
                 .unwrap();
 
             let file_content = {
-                let mut buf = Vec::new();
+                let mut buf = ::std::vec::Vec::new();
                 file.read_to_end(&mut buf).unwrap();
-                String::from_utf8_lossy(&buf).into_owned()
+                ::std::string::String::from_utf8_lossy(&buf).into_owned()
             };
 
             if update_snaps {
                 file.write_all(&writer).unwrap();
             } else {
-                std::fs::remove_file(file_path).unwrap();
-                pretty_assertions::assert_str_eq!(file_content, doc_content);
+                ::std::fs::remove_file(file_path).unwrap();
+                ::pretty_assertions::assert_str_eq!(file_content, doc_content);
             }
         }
     }};

--- a/pdfgen/tests/macros/mod.rs
+++ b/pdfgen/tests/macros/mod.rs
@@ -1,3 +1,4 @@
+/// Gives the fully qualified name of the function.
 #[macro_export]
 macro_rules! function_name {
     () => {{
@@ -16,6 +17,10 @@ macro_rules! function_name {
     }};
 }
 
+/// Snapshot tests a given [`Document`], producing a PDF file with test (function) name as it's
+/// name, inside of a directory that corresponds to the module path.
+///
+/// [`Document`]: pdfgen::Document
 #[macro_export]
 macro_rules! snap_test {
     ($doc:ident) => {{


### PR DESCRIPTION
### What?
This commit fixes the issue by using absolute paths inside of the `snap_test` macro.
This makes it impossible to influence the code produced by macro.

### Why?
Any imports that are available in scope where macro is called affect the code produced by the macro. 

### How?
Trade-off is that the macro code is a little less readable. But it does not need to be certainly readable, as it won't change often nor much. Important is that it works well. 

### Checklist
- [x] Tests are added/updated.
- [x] Documentation is added/updated.
- [x] Self-review of code changes completed.
