### PR TITLE
feat: implement support for basic UTF8 encoded PDF String

### DIFF
--- a/pdfgen/src/types/hierarchy/content/stream.rs
+++ b/pdfgen/src/types/hierarchy/content/stream.rs
@@ -8,6 +8,7 @@ use crate::types::{
 /// A stream object, like a string object, is a sequence of bytes that may be of unlimited length.
 /// Streams should be used to represent objects with potentially large amounts of data, such as
 /// images and page descriptions.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct Stream {
     /// Object ID of this `Stream`.
     id: ObjId,

--- a/pdfgen/src/types/hierarchy/primitives/mod.rs
+++ b/pdfgen/src/types/hierarchy/primitives/mod.rs
@@ -7,4 +7,5 @@ pub mod obj_id;
 pub mod object;
 pub mod rectangle;
 pub mod resources;
+pub mod string;
 pub mod unit;

--- a/pdfgen/src/types/hierarchy/primitives/obj_id.rs
+++ b/pdfgen/src/types/hierarchy/primitives/obj_id.rs
@@ -10,7 +10,7 @@ use crate::types;
 /// object number, the generation number, and the keyword R (with whitespace separating each part).
 ///
 /// Example: `4 0 R`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ObjId {
     /// Identifier of referenced object.
     id: u64,

--- a/pdfgen/src/types/hierarchy/primitives/string.rs
+++ b/pdfgen/src/types/hierarchy/primitives/string.rs
@@ -31,3 +31,28 @@ impl Object for PdfString {
         self.stream.write(writer)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::types::hierarchy::primitives::{obj_id::IdManager, object::Object};
+
+    use super::PdfString;
+
+    #[test]
+    fn simple_string() {
+        let mut id_manager = IdManager::default();
+        let pdf_string = PdfString::from(id_manager.create_id(), "This is text.");
+
+        let mut writer = Vec::default();
+        pdf_string.write(&mut writer).unwrap();
+        let output = String::from_utf8(writer).unwrap();
+
+        insta::assert_snapshot!(output, @r"
+        0 0 obj
+        << /Length 18 >>
+        stream
+        (﻿This is text.)
+        endstream
+        ");
+    }
+}

--- a/pdfgen/src/types/hierarchy/primitives/string.rs
+++ b/pdfgen/src/types/hierarchy/primitives/string.rs
@@ -1,0 +1,33 @@
+use crate::types::hierarchy::content::stream::Stream;
+
+use super::{obj_id::ObjId, object::Object};
+
+/// Represents a PDF String with UTF-8 encoding.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PdfString {
+    /// Inner [`Stream`] is the object that actually stores the bytes of a `PdfString`.
+    stream: Stream,
+}
+
+impl PdfString {
+    /// Creates a new `PdfString` with the given value that can be converted to UTF-8 encoded
+    /// [`String`].
+    pub fn from(id: ObjId, string: impl Into<String>) -> Self {
+        // NOTE: For text strings encoded in UTF-8, the first three bytes shall be 239 followed by
+        //       187, followed by 191.
+        let mut bytes = vec![239, 187, 191, b'('];
+
+        bytes.extend(string.into().into_bytes());
+        bytes.push(b')');
+
+        Self {
+            stream: Stream::with_bytes(id, bytes),
+        }
+    }
+}
+
+impl Object for PdfString {
+    fn write(&self, writer: &mut impl std::io::Write) -> Result<usize, std::io::Error> {
+        self.stream.write(writer)
+    }
+}

--- a/pdfgen/src/types/hierarchy/primitives/string.rs
+++ b/pdfgen/src/types/hierarchy/primitives/string.rs
@@ -1,3 +1,5 @@
+use std::io::{Error, Write};
+
 use crate::types::hierarchy::content::stream::Stream;
 
 use super::{obj_id::ObjId, object::Object};
@@ -27,7 +29,7 @@ impl PdfString {
 }
 
 impl Object for PdfString {
-    fn write(&self, writer: &mut impl std::io::Write) -> Result<usize, std::io::Error> {
+    fn write(&self, writer: &mut impl Write) -> Result<usize, Error> {
         self.stream.write(writer)
     }
 }

--- a/pdfgen/src/types/hierarchy/primitives/string.rs
+++ b/pdfgen/src/types/hierarchy/primitives/string.rs
@@ -15,7 +15,7 @@ impl PdfString {
     pub fn from(id: ObjId, string: impl Into<String>) -> Self {
         // NOTE: For text strings encoded in UTF-8, the first three bytes shall be 239 followed by
         //       187, followed by 191.
-        let mut bytes = vec![239, 187, 191, b'('];
+        let mut bytes = vec![b'(', 239, 187, 191];
 
         bytes.extend(string.into().into_bytes());
         bytes.push(b')');


### PR DESCRIPTION
### What?
Add support for very basic UTF8 encoded PDF String. 

### Why?
This is one of the requirements for #39. 

### How?
For now this is mostly a simple wrapper that wraps Rust's own [`String`](https://doc.rust-lang.org/std/string/struct.String.html) type. It can be created once, cannot be cloned and can be written to the PDF. 

### Notes
PDF Supports more encodings, such as ASCII String, UTF16-BE encoding etc. We will focus on UTF8 encoding **only** at least for now. This is very basic support for now, all text manipulation should be done on the Rust's string type before finally converting it into `PdfString` and writing it into a document. 

### Checklist
- [x] Tests are added/updated.
- [x] Documentation is added/updated.
- [x] Self-review of code changes completed.

### Related Issues
Closes #36 
