### PR TITLE
refactor: improve object writing for readability purposes

### DIFF
--- a/pdfgen/src/lib.rs
+++ b/pdfgen/src/lib.rs
@@ -212,38 +212,42 @@ mod tests {
         << /Type /Catalog 
         /Pages 2 0 R >>
         endobj
+
         2 0 obj
         << /Type /Pages 
         /Kids [3 0 R]
         /Count 1 >>
         endobj
+
         3 0 obj
         << /Type /Page 
         /Parent 2 0 R
         /Resources <<  >>
         /MediaBox [0 0 592.441 839.0551] >>
         endobj
+
         5 0 obj
         << /Type /Font 
         /Subtype /Type1 
         /BaseFont /Helvetica 
         >>
         endobj
+
         xref
         0 4
         0000000009 00000 n 
-        0000000059 00000 n 
-        0000000117 00000 n 
-        0000000216 00000 n 
+        0000000060 00000 n 
+        0000000119 00000 n 
+        0000000219 00000 n 
         trailer
                << /Size 4
                /Root 1 0 R
-               /ID [<eef66076f3a5b37832652f242213ef85>
-                  <eef66076f3a5b37832652f242213ef85>
+               /ID [<fbc32c429aa45e42d2bbba297e47f350>
+                  <fbc32c429aa45e42d2bbba297e47f350>
                   ]
                >>
         startxref
-        289
+        293
         %%EOF
         ");
     }

--- a/pdfgen/src/types/pdf_writer.rs
+++ b/pdfgen/src/types/pdf_writer.rs
@@ -70,6 +70,9 @@ impl<W: Write> PdfWriter<W> {
         self.current_offset += self.inner.write(Self::END_OBJ_MARKER)?;
         self.current_offset += self.inner.write(constants::NL_MARKER)?;
 
+        // spacing for readability
+        self.current_offset += self.inner.write(constants::NL_MARKER)?;
+
         Ok(())
     }
 
@@ -202,24 +205,28 @@ mod tests {
         FirstLine
         SecondLine
         endobj
+
         2 0 obj
         FirstLine
         SecondLine
         endobj
+
         3 0 obj
         FirstLine
         SecondLine
         endobj
+
         4 0 obj
         FirstLine
         SecondLine
         endobj
+
         xref
         0 4
         0000000009 00000 n 
-        0000000045 00000 n 
-        0000000081 00000 n 
-        0000000117 00000 n 
+        0000000046 00000 n 
+        0000000083 00000 n 
+        0000000120 00000 n 
         %%EOF
         "
         );
@@ -254,33 +261,37 @@ mod tests {
         FirstLine
         SecondLine
         endobj
+
         2 0 obj
         FirstLine
         SecondLine
         endobj
+
         3 0 obj
         FirstLine
         SecondLine
         endobj
+
         4 0 obj
         FirstLine
         SecondLine
         endobj
+
         xref
         0 4
         0000000009 00000 n 
-        0000000045 00000 n 
-        0000000081 00000 n 
-        0000000117 00000 n 
+        0000000046 00000 n 
+        0000000083 00000 n 
+        0000000120 00000 n 
         trailer
                << /Size 4
                /Root 5 0 R
-               /ID [<ef11002f88c2f7ddd4db3d52963e3a91>
-                  <ef11002f88c2f7ddd4db3d52963e3a91>
+               /ID [<c1708bb2c706afe7d294f9a5e79bb191>
+                  <c1708bb2c706afe7d294f9a5e79bb191>
                   ]
                >>
         startxref
-        153
+        157
         %%EOF
         "
         );

--- a/pdfgen/tests/snapshots/gen_test/page_with_image.pdf
+++ b/pdfgen/tests/snapshots/gen_test/page_with_image.pdf
@@ -3,12 +3,14 @@
 << /Type /Catalog 
 /Pages 2 0 R >>
 endobj
+
 2 0 obj
 << /Type /Pages 
 /MediaBox [0 0 64 64]
 /Kids [4 0 R]
 /Count 1 >>
 endobj
+
 4 0 obj
 << /Type /Page 
 /Parent 2 0 R
@@ -16,6 +18,7 @@ endobj
 /Contents 5 0 R
  >>
 endobj
+
 3 0 obj
 << /Type /XObject 
 /Subtype /Image 
@@ -31,6 +34,7 @@ stream
 •ZdL#(O-2K"+mBJP&(Ÿzz×¼»}dc0¤„†}t\MAoZPYE?RGDÿÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿúýÿ»»¾)""r][lEC•lk˜xzV?BÈ¶ºtflVIQ™„Œ§‰CŽQW^$x9DV)kCFÎµ³7,){rp¦—•‰pn}YS©z‹gaV96XDF% ûÿÿùÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿúÿÿÜÞå!nUSžllk23Œ]^ª‰‹]RSÈÆÊSOVª™ F (b,2NŒFI[n68Z74q^Z‚{y šœ}rsnWV—mii84™nl“rs?+/QIMûþýùÿþýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿöþÿúÿÿMJKS><‚ST¶z}f(,ŸqvB6:WZ\ºº»:(,r?Gh'.d,&Tp6+[) „e[2¨›xlqD28tZ\lGG²‰ˆjBE‘qu."’‹ÿÿûþÿúÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿüÿÿùýÿÆÅÅ(hGIX(.‰S[º—_SWgjlMPPÌ¿ÁU)1^(.e_³šsf_>0H6*´ª£oehUHPWELio‘qsP/0…ilmW\9-2íçéÿÿùÿýõÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýþûÿÿýÿÿÿ¤ž $2 &|dm)zlrFBG+-2MKO›‰_HKyhg’ƒ‹{v]SMUVShml%$,JCMhZbC.5oUWO::C891.0ÐÎÒÿÿÿþýùÿÿùÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿûÿÿûÿÿÿúøúÑÑÔzx~81;"$" #$!%)!"" $##!  # &!%"%2"#OBB“’êêíûýÿýÿÿýþûýþùÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿþüÿýÿÿýÿÿüÿÿüÿÿþÿöùûÿÿÿýÿÿ÷üøüÿýÿÿÿÿÿÿÿÿýúþúÿÿÿþþÿÿÿÿÿÿÿúýýüÿüÿÿûÿþùÿÿùÿüûÿýÿýùÿÿýÿýüÿýÿÿýÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿûÿûÿÿÿþüþÿüÿÿýÿýüÿüÿÿüÿýýÿýüÿüüÿûýÿýÿÿÿÿÿÿûÿûüÿýýÿÿÿÿÿýûýÿÿÿüÿýüÿûüÿøÿÿùûÿùÿÿýÿýÿÿüÿÿýÿÿþÿüüýýÿÿýÿÿýÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿúÿýúÿýüÿýüÿýýÿýÿÿýÿÿýÿÿýúù÷ÿÿýüüüýÿÿúýüýÿÿüÿÿùÿþøýûüÿÿüÿÿýÿÿüüýýýýýÿýûÿûûûûÿÿÿýÿýüÿüûÿûýÿÿúÿþýÿÿûüùÿÿýüüüÿÿÿýÿýûÿüüÿÿüÿÿøýûýÿÿúúûÿÿÿýýþÿÿÿýÿýúÿû÷ÿüúÿÿúÿýüÿÿûþýÿÿÿÿÿÿÿÿÿÿþÿÿþÿÿþÿÿþÿÿÿÿÿÿÿÿÿÿýÿÿúÿýúÿýüÿýýÿýÿÿýÿÿýÿÿýÿÿýÿÿÿýýþýÿÿüÿÿúÿÿúÿÿõýÿ÷ÿÿ÷ÿÿöÿÿùÿÿõýÿúÿÿúÿÿüÿÿúÿþüÿÿúþÿúÿÿúÿÿöÿÿùÿÿùÿÿúÿÿüÿÿùýÿúÿÿùÿÿøÿÿùÿÿöÿÿ÷ÿÿ÷ÿÿ÷ÿÿùÿÿùÿÿúÿÿùÿÿ÷þÿùÿÿ÷ÿÿöÿÿùÿÿúÿÿüÿÿýýþÿÿÿÿÿÿÿþÿÿþÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿýÿÿýÿÿÿÿþÿþþÿùûÿùÿÿÞåî“§ž©¶×ãòÌÛéŽ«’ ±ÊØë¡¯À˜¤³´ÀÍöÿÿ¤¯»›¨¦°ÀÛåõ– °” ­´ÀÍÊØé’ž¯”Ÿ¬ÒÝé®»Æ‘ž©´ÀÍîúÿž¯•¤²ÆÕáòÿÿ§µÆ“¡²Ûèó¿Ì×ÑÝêÆÒßÌÙäÒÝé’œ¦µ¼Åúÿÿýÿÿÿÿÿþþÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿþÿÿþÿÿþÿÿþýÿþýÿþýÿÿÿÿþÿÿÿÿüÿÿùÿÿ¼ÇÓ_k|«¿Tcy¤¶Ë“§ÀÓêØëÿUhž°ÅUgzÍÝïÂÒäAPdÇÖì½Ìà_n‚°ÃÔÇÚë¢¶Êqƒ˜ÄÓçßïÿbt‡ª¼ÏRdwµÇÜ9Lc¶ÉàAUi¾ÒæXk„“¦¿p‚•}¡£µÈš©½¡¯Â]izª´Ä€‰–åì÷üÿÿüÿÿÿÿÿÿÿÿÿÿýÿÿûÿÿûÿÿýÿÿýÿÿýÿÿÿÿýÿÿýÿÿýÿÿýÿÿþýÿþýÿÿÿÿÿÿúýÿùÿÿ÷ÿÿ»ÇÔQ_r|‹¡]o†¢µÎLaw`wÒæÿQf~Óæýs‡›¼ÐâïÿÿDXlîÿÿ»ÏãEYmr†˜­ÁÓ™®ÄI^vexÙìÿ`sŽ€“®>SiÇÜò,C^…œ·H_y´Ëåk‚´Ëæbv‘“®¤¹Ñ–©Â ²É‰–­OZn§·÷ÿÿøþÿûÿÿüÿþÿÿýÿÿûÿÿûÿÿûÿÿýÿÿÿÿÿÿÿþÿÿýÿÿýÿÿþÿÿþÿÿþýÿþýÿÿÿÿÿÿýÿÿùÿÿùÿÿ¹ÄÐXdu±¿Óãòÿ£µÌ„˜¬ÔéÿêÿÿQf|Òæún‚”ÁÕæíÿÿ@Reðÿÿ»ÏáUi{½ÑâÔèù ´È{Ž¥Öêþêýÿ`sŒ}©`u‰ãøÿ6Jer†¡™°ÈºÑémœ¶Êåez’”¬ž³É–©À›­ÂÆÔèÇÒæWaqÉÓÝùÿÿøÿÿýÿÿÿÿÿÿÿýÿÿýÿÿýÿÿÿÿþÿÿþÿÿþÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿýüÿþýÿÿúþÿÈÎÕry‚õþÿõÿÿ­¹ÈHVgZj|²ÁÕVeyGUfZiwè÷ÿix†;GXq}ŽÀÏÝv…“ñÿÿòÿÿ¥³ÄCQd]k|¸Æ×dsÓâðFVfÊÚì>Ma×çùPcrÜïþM\pM\p¢³ÀµÆÓEUeDTfÐÞïœXcpS]gëòûúÿÿúþÿüÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿþÿÿþÿÿþÿÿþÿýÿÿýÿÿýÿÿýÿÿÿÿÿÿÿýÿÿýÿÿýÿÿýÿÿÿýÿÿõøúõùýúÿÿøÿÿóúÿéóýêõÿîùÿì÷ÿêôþòüÿ÷ÿÿëõýìóþíôÿñûÿïùÿ÷ÿÿõÿÿñûÿéóýèòúôþÿí÷ÿöÿÿïúÿñüÿçòþöÿÿéöýôÿÿðûÿèóÿõÿÿôÿÿéõüêõÿöÿÿöÿÿãíõòúÿúÿÿùýÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿþÿÿþÿÿþÿÿþÿÿÿÿüÿÿüÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿýÿÿýÿÿüÿÿúÿÿúÿÿúÿÿüÿÿüÿÿüÿÿüÿÿýÿÿýÿÿüÿÿüÿÿüÿýüÿýüÿÿüÿÿüÿÿüÿÿüÿÿüÿÿúÿÿúÿÿúÿÿúÿÿùÿÿùÿÿúÿÿúÿÿúÿÿúÿÿúÿÿúÿÿúÿÿúÿÿúÿÿúÿÿüÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿýýÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿþÿÿþÿÿÿÿÿÿÿÿÿýÿÿýÿÿûÿÿûÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿûÿÿûÿÿýÿÿÿÿÿýÿÿûÿÿùÿÿùÿÿûÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿûÿÿýýÿÿýÿÿýÿÿýÿýýÿÿýÿÿýÿÿýÿÿýÿÿýÿÿýÿÿýÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýýÿýÿÿûÿÿûÿÿýÿÿÿÿþÿÿþÿÿþÿÿþÿÿþÿÿþÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿþÿÿþÿÿþÿÿþÿÿþÿÿÿÿÿÿÿÿþÿÿþÿÿþÿÿÿÿÿÿýÿÿýÿÿÿÿþÿÿÿÿÿÿÿÿÿýÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿþÿÿþÿÿþÿÿþÿÿÿÿÿÿÿÿÿÿÿÿÿýÿýýÿûýÿûýÿ÷ÿÿûÿÿûÿÿýÿÿÿÿþÿÿþÿÿþÿÿþÿÿþÿÿþÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿþÿÿþÿÿþÿÿýÿÿþÿÿþÿÿþÿÿþÿÿþÿÿþÿÿþÿÿþÿÿÿÿÿÿÿÿþÿÿþÿÿþÿÿÿÿÿÿýÿÿýÿÿÿÿþÿÿþÿÿþÿÿÿýÿÿýÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿþÿÿþÿÿþÿÿþÿÿÿÿÿÿÿÿÿÿÿÿýýÿûýÿùýÿùýÿ÷ÿþýÿþýÿÿÿÿÿÿÿþÿÿþÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿþÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿûÿÿûÿÿûÿÿùÿÿÿÿÿÿÿþÿÿþÿÿþÿÿþÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿýýÿýÿÿûÿÿûÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿýýÿýýÿÿýÿÿýÿÿýÿýýÿûýÿýýÿÿýÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýýÿýýÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿþÿýÿÿýÿÿýÿÿýÿÿýÿÿýÿÿýÿýýÿûÿÿùÿÿùÿÿûÿÿûÿÿýÿÿýÿÿýÿÿýÿÿûýÿýýÿÿýÿÿýÿÿýÿýýÿûýÿýýÿÿýÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿýÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿûÿÿûÿÿÿÿÿÿÿÿýÿÿýÿÿÿÿÿÿÿÿÿÿÿÿýÿÿýÿÿýÿýýÿýýÿýýÿýÿÿýÿÿÿÿÿÿÿÿÿÿþÿÿþÿÿþÿÿýÿ
 endstream
 endobj
+
 5 0 obj
 << /Length 28 >>
 stream
@@ -40,20 +44,21 @@ q
 Q
 endstream
 endobj
+
 xref
 0 5
 0000000009 00000 n 
-0000000059 00000 n 
-0000000139 00000 n 
-0000000247 00000 n 
-0000012686 00000 n 
+0000000060 00000 n 
+0000000141 00000 n 
+0000000250 00000 n 
+0000012690 00000 n 
 trailer
        << /Size 5
        /Root 1 0 R
-       /ID [<ca20691f9de798f1a93d79742126a24c>
-          <ca20691f9de798f1a93d79742126a24c>
+       /ID [<653d0e18d93948a4fbbebc2917e8d8ff>
+          <653d0e18d93948a4fbbebc2917e8d8ff>
           ]
        >>
 startxref
-12764
+12769
 %%EOF

--- a/pdfgen/tests/snapshots/gen_test/public_api.pdf
+++ b/pdfgen/tests/snapshots/gen_test/public_api.pdf
@@ -3,30 +3,33 @@
 << /Type /Catalog 
 /Pages 2 0 R >>
 endobj
+
 2 0 obj
 << /Type /Pages 
 /MediaBox [0 0 416.69293 592.441]
 /Kids [3 0 R]
 /Count 1 >>
 endobj
+
 3 0 obj
 << /Type /Page 
 /Parent 2 0 R
 /Resources <<  >>
  >>
 endobj
+
 xref
 0 3
 0000000009 00000 n 
-0000000059 00000 n 
-0000000151 00000 n 
+0000000060 00000 n 
+0000000153 00000 n 
 trailer
        << /Size 3
        /Root 1 0 R
-       /ID [<9ad019b67038b471c1d95b0d35949873>
-          <9ad019b67038b471c1d95b0d35949873>
+       /ID [<5adf24d914095b52876e29fa640cdf82>
+          <5adf24d914095b52876e29fa640cdf82>
           ]
        >>
 startxref
-218
+221
 %%EOF

--- a/pdfgen/tests/snapshots/gen_test/three_pages_different_size.pdf
+++ b/pdfgen/tests/snapshots/gen_test/three_pages_different_size.pdf
@@ -3,6 +3,7 @@
 << /Type /Catalog 
 /Pages 2 0 R >>
 endobj
+
 2 0 obj
 << /Type /Pages 
 /MediaBox [0 0 592.441 839.0551]
@@ -11,38 +12,42 @@ endobj
        7 0 R]
 /Count 3 >>
 endobj
+
 3 0 obj
 << /Type /Page 
 /Parent 2 0 R
 /Resources <<  >>
  >>
 endobj
+
 5 0 obj
 << /Type /Page 
 /Parent 2 0 R
 /Resources <<  >>
 /MediaBox [0 0 416.69293 592.441] >>
 endobj
+
 7 0 obj
 << /Type /Page 
 /Parent 2 0 R
 /Resources <<  >>
  >>
 endobj
+
 xref
 0 5
 0000000009 00000 n 
-0000000059 00000 n 
-0000000176 00000 n 
-0000000243 00000 n 
-0000000343 00000 n 
+0000000060 00000 n 
+0000000178 00000 n 
+0000000246 00000 n 
+0000000347 00000 n 
 trailer
        << /Size 5
        /Root 1 0 R
-       /ID [<fa59334f8d8723cab540fbbc25a47454>
-          <fa59334f8d8723cab540fbbc25a47454>
+       /ID [<47182dc584b15196f263c09096e945d9>
+          <47182dc584b15196f263c09096e945d9>
           ]
        >>
 startxref
-410
+415
 %%EOF

--- a/pdfgen/tests/snapshots/gen_test/two_empty_pages.pdf
+++ b/pdfgen/tests/snapshots/gen_test/two_empty_pages.pdf
@@ -3,6 +3,7 @@
 << /Type /Catalog 
 /Pages 2 0 R >>
 endobj
+
 2 0 obj
 << /Type /Pages 
 /MediaBox [0 0 416.69293 592.441]
@@ -10,31 +11,34 @@ endobj
        5 0 R]
 /Count 2 >>
 endobj
+
 3 0 obj
 << /Type /Page 
 /Parent 2 0 R
 /Resources <<  >>
  >>
 endobj
+
 5 0 obj
 << /Type /Page 
 /Parent 2 0 R
 /Resources <<  >>
  >>
 endobj
+
 xref
 0 4
 0000000009 00000 n 
-0000000059 00000 n 
-0000000164 00000 n 
-0000000231 00000 n 
+0000000060 00000 n 
+0000000166 00000 n 
+0000000234 00000 n 
 trailer
        << /Size 4
        /Root 1 0 R
-       /ID [<9170d8b46a52fa5220985ed3e28b39be>
-          <9170d8b46a52fa5220985ed3e28b39be>
+       /ID [<fcc921d4474d7b40800d06f044fac32e>
+          <fcc921d4474d7b40800d06f044fac32e>
           ]
        >>
 startxref
-298
+302
 %%EOF


### PR DESCRIPTION
### What?
This PR adds an additional `NL` after each `endobj` to create a visual gap in the document.

### Why?
To improve readability and visual testing.

### How?
By introducing an additional write of the `NL` at the end of `write_object` and updating the tests to accomodate that.

### Notes
N/A

### Checklist
- [x] Tests are added/updated.
- [x] Documentation is added/updated.
- [x] Self-review of code changes completed.

### Related Issues
N/A
