### PR TITLE
refactor: add type-safety to `ObjId`

### DIFF
--- a/pdfgen/src/document/mod.rs
+++ b/pdfgen/src/document/mod.rs
@@ -74,8 +74,7 @@ impl Document {
     pub fn create_font(&mut self, subtype: Vec<u8>, base_type: Vec<u8>) -> ObjId<Font> {
         let id = self.id_manager.create_id();
 
-        self.fonts
-            .push(Font::new(id.clone().cast(), subtype, base_type));
+        self.fonts.push(Font::new(id.clone(), subtype, base_type));
 
         id
     }

--- a/pdfgen/src/document/mod.rs
+++ b/pdfgen/src/document/mod.rs
@@ -71,10 +71,11 @@ impl Document {
     }
 
     /// Creates a new font inside the document.
-    pub fn create_font(&mut self, subtype: Vec<u8>, base_type: Vec<u8>) -> ObjId {
+    pub fn create_font(&mut self, subtype: Vec<u8>, base_type: Vec<u8>) -> ObjId<Font> {
         let id = self.id_manager.create_id();
 
-        self.fonts.push(Font::new(id.clone(), subtype, base_type));
+        self.fonts
+            .push(Font::new(id.clone().cast(), subtype, base_type));
 
         id
     }

--- a/pdfgen/src/document/obj_id.rs
+++ b/pdfgen/src/document/obj_id.rs
@@ -11,7 +11,7 @@ use std::{
 /// object number, the generation number, and the keyword R (with whitespace separating each part).
 ///
 /// Example: `4 0 R`
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ObjId<T = ()> {
     /// Identifier of referenced object.
     id: u64,
@@ -20,7 +20,16 @@ pub struct ObjId<T = ()> {
     _marker: PhantomData<T>,
 }
 
-impl ObjId {
+impl<T> Clone for ObjId<T> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> ObjId<T> {
     /// Marker indicating start of an object section
     const START_OBJ_MARKER: &[u8] = b"obj";
 
@@ -43,6 +52,13 @@ impl ObjId {
             writer.write(b" 0 "),
             writer.write(Self::START_OBJ_MARKER),
         })
+    }
+
+    pub(crate) fn cast<U>(self) -> ObjId<U> {
+        ObjId {
+            id: self.id,
+            _marker: PhantomData,
+        }
     }
 }
 

--- a/pdfgen/src/document/obj_id.rs
+++ b/pdfgen/src/document/obj_id.rs
@@ -1,6 +1,9 @@
 //! Implementation of PDF object reference.
 
-use std::io::{Error, Write};
+use std::{
+    io::{Error, Write},
+    marker::PhantomData,
+};
 
 /// Any object in a PDF file may be labelled as an indirect object. This gives the object a unique
 /// object identifier by which other objects can refer to it. The object may be referred to from
@@ -9,9 +12,12 @@ use std::io::{Error, Write};
 ///
 /// Example: `4 0 R`
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ObjId {
+pub struct ObjId<T = ()> {
     /// Identifier of referenced object.
     id: u64,
+
+    /// Marks the type of object this ObjId refers to.
+    _marker: PhantomData<T>,
 }
 
 impl ObjId {
@@ -55,9 +61,12 @@ impl IdManager {
         Self { curr: self.curr }
     }
 
-    pub fn create_id(&mut self) -> ObjId {
+    pub fn create_id<T>(&mut self) -> ObjId<T> {
         let inner_id = self.curr;
         self.curr += 1;
-        ObjId { id: inner_id }
+        ObjId {
+            id: inner_id,
+            _marker: PhantomData,
+        }
     }
 }

--- a/pdfgen/src/types/hierarchy/catalog.rs
+++ b/pdfgen/src/types/hierarchy/catalog.rs
@@ -20,7 +20,7 @@ use super::{
 #[derive(Debug)]
 pub struct Catalog {
     /// The object reference allocated to this `Catalog`.
-    id: ObjId,
+    id: ObjId<Self>,
 
     /// Reference to the root [`PageTree`] of the PDF Document.
     root_page_tree: PageTree,
@@ -33,7 +33,7 @@ impl Catalog {
     }
 
     /// Create a new `Catalog` with the given [`ObjId`] and [`PageTree`].
-    pub(crate) fn new(obj_ref: ObjId, root_page_tree: PageTree) -> Self {
+    pub(crate) fn new(obj_ref: ObjId<Self>, root_page_tree: PageTree) -> Self {
         Self {
             id: obj_ref,
             root_page_tree,
@@ -41,7 +41,7 @@ impl Catalog {
     }
 
     /// Returns the [`ObjId`] allocated to this `Catalog`.
-    pub(crate) fn obj_ref(&self) -> ObjId {
+    pub(crate) fn obj_ref(&self) -> ObjId<Self> {
         self.id.clone()
     }
 

--- a/pdfgen/src/types/hierarchy/content/content_stream.rs
+++ b/pdfgen/src/types/hierarchy/content/content_stream.rs
@@ -45,7 +45,7 @@ pub(crate) enum Operation<'a> {
 /// [`Page`]: crate::types::hierarchy::page::Page
 #[derive(Debug, PartialEq, PartialOrd)]
 pub struct ContentStream {
-    id: ObjId,
+    id: ObjId<Self>,
 
     /// Inner stream object containing the actual bytes of the content.
     stream: Stream,
@@ -53,7 +53,7 @@ pub struct ContentStream {
 
 impl ContentStream {
     /// Creates a new `ContentStream` with the given [`ObjId`].
-    pub fn new(id: ObjId) -> Self {
+    pub fn new(id: ObjId<Self>) -> Self {
         Self {
             id,
             stream: Stream::new(),
@@ -110,7 +110,7 @@ impl ContentStream {
         self.stream.is_empty()
     }
 
-    pub(crate) fn obj_ref(&self) -> &ObjId {
+    pub(crate) fn obj_ref(&self) -> &ObjId<Self> {
         &self.id
     }
 }

--- a/pdfgen/src/types/hierarchy/page.rs
+++ b/pdfgen/src/types/hierarchy/page.rs
@@ -6,17 +6,18 @@ use crate::{IdManager, ObjId, types::constants};
 
 use super::{
     content::{ContentStream, Operation, image::Image, text::Text},
-    primitives::{name::Name, rectangle::Rectangle, resources::Resources},
+    page_tree::PageTree,
+    primitives::{font::Font, name::Name, rectangle::Rectangle, resources::Resources},
 };
 
 /// Page objects are the leaves of the page tree, each of which is a dictionary specifying the
 /// attributes of a single page of the document.
 pub struct Page {
     /// ID of this Page object.
-    id: ObjId,
+    id: ObjId<Self>,
 
     /// The page tree node that is the immediate parent of this page object.
-    parent: ObjId,
+    parent: ObjId<PageTree>,
 
     /// A dictionary containing any resources required by the page contents. If the page requires
     /// no resources, the value of this entry shall be an empty dictionary.
@@ -40,7 +41,11 @@ impl Page {
     }
 
     /// Create a new blank page that belongs to the given parent and media box.
-    pub fn new(id: ObjId, contents_id: ObjId, parent: ObjId) -> Self {
+    pub fn new(
+        id: ObjId<Self>,
+        contents_id: ObjId<ContentStream>,
+        parent: ObjId<PageTree>,
+    ) -> Self {
         Self {
             id,
             parent,
@@ -55,7 +60,7 @@ impl Page {
     }
 
     /// Returns the object reference of this Page object.
-    pub fn obj_ref(&self) -> ObjId {
+    pub fn obj_ref(&self) -> ObjId<Self> {
         self.id.clone()
     }
 
@@ -83,7 +88,7 @@ impl Page {
     }
 
     /// Adds a text to the PDF page.
-    pub fn add_text(&mut self, text: Text, font_id: ObjId) {
+    pub fn add_text(&mut self, text: Text, font_id: ObjId<Font>) {
         let font_name = self.resources.add_font(font_id);
 
         self.contents

--- a/pdfgen/src/types/hierarchy/page_tree.rs
+++ b/pdfgen/src/types/hierarchy/page_tree.rs
@@ -7,7 +7,10 @@ use crate::{
     types::{constants, hierarchy::primitives::name::Name},
 };
 
-use super::primitives::{array::WriteArray, object::Object, rectangle::Rectangle};
+use super::{
+    page::Page,
+    primitives::{array::WriteArray, object::Object, rectangle::Rectangle},
+};
 
 /// Page tree is a structure which defines the ordering of pages in the document. The tree contains
 /// nodes of two types:
@@ -23,11 +26,11 @@ use super::primitives::{array::WriteArray, object::Object, rectangle::Rectangle}
 #[derive(Debug, Clone)]
 pub struct PageTree {
     /// The object reference allocated for this `PageTree`.
-    id: ObjId,
+    id: ObjId<Self>,
 
     /// The page tree node that is the immediate parent of this one. Required for all nodes except
     /// the root node.
-    parent: Option<ObjId>,
+    parent: Option<ObjId<Self>>,
 
     /// An array of indirect references to the immediate children of this node. The children shall
     /// only be [`Page`] objects or other [`PageTree`] nodes.
@@ -56,7 +59,7 @@ impl PageTree {
         COUNT,
     }
 
-    pub fn new(obj_id: ObjId, parent: Option<&PageTree>) -> Self {
+    pub fn new(obj_id: ObjId<Self>, parent: Option<&PageTree>) -> Self {
         Self {
             id: obj_id,
             parent: parent.map(|parent| parent.obj_ref()),
@@ -67,7 +70,7 @@ impl PageTree {
     }
 
     pub fn with_mediabox(
-        obj_id: ObjId,
+        obj_id: ObjId<Self>,
         parent: Option<&PageTree>,
         mediabox: impl Into<Rectangle>,
     ) -> Self {
@@ -76,12 +79,12 @@ impl PageTree {
         page_tree
     }
 
-    pub fn add_page(&mut self, page: ObjId) {
-        self.kids.push(page);
+    pub fn add_page(&mut self, page: ObjId<Page>) {
+        self.kids.push(page.cast());
         self.count += 1;
     }
 
-    pub fn obj_ref(&self) -> ObjId {
+    pub fn obj_ref(&self) -> ObjId<Self> {
         self.id.clone()
     }
 

--- a/pdfgen/src/types/hierarchy/primitives/font.rs
+++ b/pdfgen/src/types/hierarchy/primitives/font.rs
@@ -16,7 +16,7 @@ use super::{name::Name, object::Object};
 #[derive(Debug)]
 pub struct Font {
     /// ID of this [`Font`] object.
-    pub(crate) id: ObjId,
+    pub(crate) id: ObjId<Self>,
 
     /// Specifies the subtype of the font, defining its role or characteristics within the PDF.
     subtype: Name<Vec<u8>>,
@@ -33,7 +33,7 @@ impl Font {
     }
 
     /// Create a new [`Font`] object with the provided id, subtype and base_font.
-    pub fn new<S, B>(id: ObjId, subtype: S, base_font: B) -> Self
+    pub fn new<S, B>(id: ObjId<Self>, subtype: S, base_font: B) -> Self
     where
         S: Into<Vec<u8>>,
         B: Into<Vec<u8>>,

--- a/pdfgen/src/types/hierarchy/primitives/resources.rs
+++ b/pdfgen/src/types/hierarchy/primitives/resources.rs
@@ -4,14 +4,17 @@ use std::io::{Error, Write};
 
 use crate::{IdManager, ObjId, types::hierarchy::content::image::Image};
 
-use super::name::{Name, OwnedName};
+use super::{
+    font::Font,
+    name::{Name, OwnedName},
+};
 
 /// Represents a single entry in the [`Resources`] dictionary.
 #[derive(Debug)]
 #[non_exhaustive]
 pub(crate) enum ResourceEntry {
     Image { name: OwnedName, image: Image },
-    Font { name: OwnedName, id: ObjId },
+    Font { name: OwnedName, id: ObjId<Font> },
 }
 
 /// Resource dictionary enumerates the named resources needed by the operators in the content
@@ -61,7 +64,7 @@ impl Resources {
     /// Adds a reference to a [`Font`] to this `Resources` dictionary.
     ///
     /// [`Font`]: crate::types::hierarchy::primitives::font::Font
-    pub(crate) fn add_font(&mut self, font_id: ObjId) -> Name<&[u8]> {
+    pub(crate) fn add_font(&mut self, font_id: ObjId<Font>) -> Name<&[u8]> {
         let name = self.create_name("F");
         let fnt = ResourceEntry::Font { name, id: font_id };
 

--- a/pdfgen/src/types/hierarchy/trailer.rs
+++ b/pdfgen/src/types/hierarchy/trailer.rs
@@ -7,6 +7,7 @@ use pdfgen_macros::const_names;
 use crate::{ObjId, types::constants};
 
 use super::{
+    catalog::Catalog,
     cross_reference_table::CrossReferenceTable,
     primitives::{array::WriteArray, name::Name},
 };
@@ -20,7 +21,7 @@ pub trait WriteTrailer {
         writer: &mut impl Write,
         offset: usize,
         size: usize,
-        root: ObjId,
+        root: ObjId<Catalog>,
         id: [u8; 16],
     ) -> Result<(), std::io::Error>;
 }
@@ -31,7 +32,7 @@ impl WriteTrailer for CrossReferenceTable {
         writer: &mut impl Write,
         offset: usize,
         size: usize,
-        root: ObjId,
+        root: ObjId<Catalog>,
         id: [u8; 16],
     ) -> Result<(), std::io::Error> {
         const_names! {

--- a/pdfgen/src/types/pdf_writer.rs
+++ b/pdfgen/src/types/pdf_writer.rs
@@ -5,7 +5,7 @@ use crate::{IdManager, ObjId};
 use super::{
     constants,
     hierarchy::{
-        cross_reference_table::CrossReferenceTable, primitives::object::Object,
+        catalog::Catalog, cross_reference_table::CrossReferenceTable, primitives::object::Object,
         trailer::WriteTrailer,
     },
     page::Page,
@@ -82,7 +82,7 @@ impl<W: Write> PdfWriter<W> {
     }
 
     /// Writes the trailer for the PdfWriter's CRT.
-    pub fn write_trailer(&mut self, root: ObjId) -> Result<(), io::Error> {
+    pub fn write_trailer(&mut self, root: ObjId<Catalog>) -> Result<(), io::Error> {
         self.cross_reference_table.write_trailer(
             &mut self.inner,
             self.current_offset,


### PR DESCRIPTION
### What?
Add type safety to `ObjId` so that it can't be misused.

### Why?
We want to enforce users to pass references to correct objects. Since we control creation of `ObjId` instances, we can enforce that any given instance points to the expected object (e.g. reference to a Font vs. reference to an Image). 

### How?
`PhantomData` is used as a marker for generic type on `ObjId`. Default is `()` which would represent a reference to *any* PDF object. This makes it possible to store references to different types of objects. Also a `ObjId::cast()` method is implemented that easily converts between references to any types.

### Checklist
- [x] Tests are added/updated.
- [x] Documentation is added/updated.
- [x] Self-review of code changes completed.
