### PR TITLE
refactor: avoid allocating when writing formatted strings

### DIFF
--- a/pdfgen/src/lib.rs
+++ b/pdfgen/src/lib.rs
@@ -8,3 +8,4 @@ pub mod types;
 mod document;
 pub use document::Document;
 pub(crate) use document::{IdManager, ObjId};
+pub(crate) mod macros;

--- a/pdfgen/src/macros.rs
+++ b/pdfgen/src/macros.rs
@@ -1,0 +1,28 @@
+use std::fmt;
+
+pub(crate) struct WriteCounter<W> {
+    pub(crate) writer: W,
+    pub(crate) counter: usize,
+}
+
+impl<W: std::io::Write> std::fmt::Write for WriteCounter<W> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let bytes = s.as_bytes();
+        self.writer.write_all(bytes).map_err(|_| fmt::Error)?;
+        self.counter += bytes.len();
+        Ok(())
+    }
+}
+
+#[macro_export]
+macro_rules! write_fmt {
+    ($dst:expr, $($arg:tt)*) => {{
+        let mut writer = $crate::macros::WriteCounter { writer: $dst, counter: 0 };
+
+        if std::fmt::write(&mut writer, ::std::format_args!($($arg)*)).is_err() {
+            return Err(std::io::Error::other("could not write formatted string"));
+        }
+
+        Ok::<usize, std::io::Error>(writer.counter)
+    }};
+}

--- a/pdfgen/src/types/hierarchy/content/image.rs
+++ b/pdfgen/src/types/hierarchy/content/image.rs
@@ -199,7 +199,7 @@ impl Object for Image {
         //       colour space specified in the dictionary.
 
         Ok(pdfgen_macros::write_chain! {
-            self.samples.write_with_dict(writer, |writer| {
+            self.samples.write_with_dict(writer, |mut writer| {
                 Ok(pdfgen_macros::write_chain! {
                     Name::TYPE.write(writer),
                     Name::X_OBJECT.write(writer),
@@ -210,11 +210,11 @@ impl Object for Image {
                     writer.write(constants::NL_MARKER),
 
                     Self::WIDTH.write(writer),
-                    writer.write(format!("{}", self.dict.width).as_bytes()),
+                    crate::write_fmt!(&mut writer, "{}", self.dict.width),
                     writer.write(constants::NL_MARKER),
 
                     Self::HEIGHT.write(writer),
-                    writer.write(format!("{}", self.dict.height).as_bytes()),
+                    crate::write_fmt!(&mut writer, "{}", self.dict.height),
                     writer.write(constants::NL_MARKER),
 
                     Self::COLOR_SPACE.write(writer),
@@ -222,7 +222,7 @@ impl Object for Image {
                     writer.write(constants::NL_MARKER),
 
                     Self::BITS_PER_COMPONENT.write(writer),
-                    writer.write(format!("{}", self.dict.bits_per_comp).as_bytes()),
+                    crate::write_fmt!(&mut writer, "{}", self.dict.bits_per_comp),
                     writer.write(constants::NL_MARKER),
                 })
             }),

--- a/pdfgen/src/types/hierarchy/cross_reference_table.rs
+++ b/pdfgen/src/types/hierarchy/cross_reference_table.rs
@@ -25,13 +25,13 @@ impl CrossReferenceTable {
 
     /// Writes the contents of the `offsets`, representing them in the format required by the PDF
     /// syntax, `10 byte offset generation(00000), n`.
-    pub fn write(&self, writer: &mut impl Write) -> Result<(), std::io::Error> {
+    pub fn write(&self, mut writer: &mut impl Write) -> Result<(), std::io::Error> {
         pdfgen_macros::write_chain! {
             writer.write(Self::XREF_MARKER),
-            writer.write(format!("0 {}\n", self.offsets.len()).as_bytes()),
+            crate::write_fmt!(&mut writer, "0 {}\n", self.offsets.len()),
 
             for offset in self.offsets.iter() {
-                writer.write(format!("{offset:010} 00000 n{}", Self::SP_LF).as_bytes()),
+                crate::write_fmt!(&mut writer, "{offset:010} 00000 n{}", Self::SP_LF),
             },
         };
 


### PR DESCRIPTION
### What?
We are writing strings using the `format!().as_bytes()` pattern. This allocates a `String`, but it does not have to do it. This PR implements small helper macro that avoids this allocation.

### Why?
We want to avoid allocation where it's not necessary.

### How?
Small adapter struct is implemented `WriteCounter` that implements `std::fmt::Write` trait. This is then used with `fmt::write` function to write contents for `format_args!()` into it and simply count number of bytes written. This mechanism is then wrapped with small helper macro that is similar to `std::write!()` and `format!()` macros, but avoids allocating a `String`. 

### Checklist
- [x] Tests are added/updated.
- [x] Documentation is added/updated.
- [x] Self-review of code changes completed.

### Related Issues
Closes #57 
