### PR TITLE
refactor: rename `Name` to `Identifier`

### DIFF
--- a/pdfgen/src/types/hierarchy/catalog.rs
+++ b/pdfgen/src/types/hierarchy/catalog.rs
@@ -1,12 +1,12 @@
 use std::io::Error;
 
-use pdfgen_macros::const_names;
+use pdfgen_macros::const_identifiers;
 
 use crate::{ObjId, types::constants};
 
 use super::{
     page_tree::PageTree,
-    primitives::{name::Name, object::Object},
+    primitives::{identifier::Identifier, object::Object},
 };
 
 /// The root of a document’s object hierarchy, located by means of the `Root` entry in the trailer
@@ -27,7 +27,7 @@ pub struct Catalog {
 }
 
 impl Catalog {
-    const_names! {
+    const_identifiers! {
         CATALOG,
         PAGES,
     }
@@ -68,7 +68,7 @@ impl Object for Catalog {
         let written = pdfgen_macros::write_chain! {
             writer.write(b"<< "),
 
-            Name::TYPE.write(writer),
+            Identifier::TYPE.write(writer),
             Self::CATALOG.write(writer),
             writer.write(constants::NL_MARKER),
 

--- a/pdfgen/src/types/hierarchy/content/content_stream.rs
+++ b/pdfgen/src/types/hierarchy/content/content_stream.rs
@@ -2,7 +2,7 @@ use crate::{
     ObjId,
     types::{
         constants,
-        hierarchy::primitives::{name::Name, object::Object, rectangle::Position},
+        hierarchy::primitives::{identifier::Identifier, object::Object, rectangle::Position},
     },
 };
 
@@ -17,7 +17,7 @@ pub(crate) enum Operation<'a> {
         /// [`Image`]: super::image::Image
         /// [`Resources`]: crate::types::hierarchy::primitives::resources::Resources
         /// [`Page`]: crate::types::hierarchy::page::Page
-        name: Name<&'a [u8]>,
+        name: Identifier<&'a [u8]>,
 
         /// Transformation that should be applied to the [`Image`] in Pdf.
         ///
@@ -35,7 +35,7 @@ pub(crate) enum Operation<'a> {
         /// [`Font`]: crate::types::hierarchy::primitives::font::Font
         /// [`Resources`]: crate::types::hierarchy::primitives::resources::Resources
         /// [`Page`]: crate::types::hierarchy::page::Page
-        font_name: Name<&'a [u8]>,
+        font_name: Identifier<&'a [u8]>,
     },
 }
 
@@ -70,7 +70,7 @@ impl ContentStream {
     }
 
     /// Encodes an image in this `ContentStream`.
-    fn draw_image(&mut self, name: Name<&[u8]>, transform: ImageTransform) {
+    fn draw_image(&mut self, name: Identifier<&[u8]>, transform: ImageTransform) {
         let Position {
             x: width,
             y: height,
@@ -98,7 +98,7 @@ impl ContentStream {
     }
 
     /// Encodes a text object in this `ContentStream`.
-    fn draw_text(&mut self, text: Text, font_name: Name<&[u8]>) {
+    fn draw_text(&mut self, text: Text, font_name: Identifier<&[u8]>) {
         self.stream.push_bytes(
             &text
                 .to_bytes(font_name)

--- a/pdfgen/src/types/hierarchy/content/image.rs
+++ b/pdfgen/src/types/hierarchy/content/image.rs
@@ -3,13 +3,15 @@
 use std::io::{BufReader, Cursor, Error, Read, Write};
 
 use image::ImageReader;
-use pdfgen_macros::const_names;
+use pdfgen_macros::const_identifiers;
 
 use crate::{
     ObjId,
     types::{
         constants,
-        hierarchy::primitives::{name::Name, object::Object, rectangle::Position, unit::Unit},
+        hierarchy::primitives::{
+            identifier::Identifier, object::Object, rectangle::Position, unit::Unit,
+        },
     },
 };
 
@@ -31,8 +33,8 @@ impl ColorSpace {
     /// Encode this `ColorSpace` into the given implementor of [`Write`].
     fn write(&self, writer: &mut dyn Write) -> Result<usize, Error> {
         match self {
-            ColorSpace::DeviceRgb => Name::new(b"DeviceRGB").write(writer),
-            ColorSpace::DeviceGray => Name::new(b"DeviceGray").write(writer),
+            ColorSpace::DeviceRgb => Identifier::new(b"DeviceRGB").write(writer),
+            ColorSpace::DeviceGray => Identifier::new(b"DeviceGray").write(writer),
         }
     }
 }
@@ -95,7 +97,7 @@ pub struct Image {
 }
 
 impl Image {
-    const_names! {
+    const_identifiers! {
         SUBTYPE,
         IMAGE,
         WIDTH,
@@ -201,8 +203,8 @@ impl Object for Image {
         Ok(pdfgen_macros::write_chain! {
             self.samples.write_with_dict(writer, |mut writer| {
                 Ok(pdfgen_macros::write_chain! {
-                    Name::TYPE.write(writer),
-                    Name::X_OBJECT.write(writer),
+                    Identifier::TYPE.write(writer),
+                    Identifier::X_OBJECT.write(writer),
                     writer.write(constants::NL_MARKER),
 
                     Self::SUBTYPE.write(writer),

--- a/pdfgen/src/types/hierarchy/content/stream.rs
+++ b/pdfgen/src/types/hierarchy/content/stream.rs
@@ -1,8 +1,8 @@
 use std::io::{Error, Write};
 
-use pdfgen_macros::const_names;
+use pdfgen_macros::const_identifiers;
 
-use crate::types::{constants, hierarchy::primitives::name::Name};
+use crate::types::{constants, hierarchy::primitives::identifier::Identifier};
 
 /// A stream object, like a string object, is a sequence of bytes that may be of unlimited length.
 /// Streams should be used to represent objects with potentially large amounts of data, such as
@@ -20,7 +20,7 @@ pub(crate) struct Stream {
 impl Stream {
     const START_STREAM: &[u8] = b"stream";
     const END_STREAM: &[u8] = b"endstream";
-    const_names!(LENGTH);
+    const_identifiers!(LENGTH);
 
     /// Creates a new empty `Stream`, containing no bytes and with length 0.
     pub fn new() -> Self {

--- a/pdfgen/src/types/hierarchy/content/text.rs
+++ b/pdfgen/src/types/hierarchy/content/text.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 
 use crate::types::{
     constants,
-    hierarchy::primitives::{name::Name, rectangle::Position, string::PdfString},
+    hierarchy::primitives::{identifier::Identifier, rectangle::Position, string::PdfString},
 };
 
 /// Defines the transformation properties of a [`Text`] object, including its position and size on a [`Page`].
@@ -67,7 +67,7 @@ impl Text {
     }
 
     /// Returns a byte representation for drawing operations of this `Text` object in PDF syntax.
-    pub(crate) fn to_bytes(&self, font_name: Name<&[u8]>) -> io::Result<Vec<u8>> {
+    pub(crate) fn to_bytes(&self, font_name: Identifier<&[u8]>) -> io::Result<Vec<u8>> {
         let mut writer = Vec::new();
 
         // BT
@@ -148,7 +148,7 @@ impl TextBuilder<true> {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::hierarchy::{content::text::Name, primitives::rectangle::Position};
+    use crate::types::hierarchy::{content::text::Identifier, primitives::rectangle::Position};
 
     use super::Text;
 
@@ -157,7 +157,7 @@ mod tests {
         let txt = Text::builder()
             .at(Position::from_mm(0.0, 0.0))
             .build()
-            .to_bytes(Name::from_static(b"BiHDef"))
+            .to_bytes(Identifier::from_static(b"BiHDef"))
             .unwrap();
 
         let output = String::from_utf8_lossy(&txt);
@@ -178,7 +178,7 @@ mod tests {
             .with_size(14)
             .at(Position::from_mm(0.0, 0.0))
             .build()
-            .to_bytes(Name::from_static(b"CustomFnt"))
+            .to_bytes(Identifier::from_static(b"CustomFnt"))
             .unwrap();
 
         let output = String::from_utf8_lossy(&txt);

--- a/pdfgen/src/types/hierarchy/page.rs
+++ b/pdfgen/src/types/hierarchy/page.rs
@@ -1,13 +1,13 @@
 use std::io::{Error, Write};
 
-use pdfgen_macros::const_names;
+use pdfgen_macros::const_identifiers;
 
 use crate::{IdManager, ObjId, types::constants};
 
 use super::{
     content::{ContentStream, Operation, image::Image, text::Text},
     page_tree::PageTree,
-    primitives::{font::Font, name::Name, rectangle::Rectangle, resources::Resources},
+    primitives::{font::Font, identifier::Identifier, rectangle::Rectangle, resources::Resources},
 };
 
 /// Page objects are the leaves of the page tree, each of which is a dictionary specifying the
@@ -32,7 +32,7 @@ pub struct Page {
 }
 
 impl Page {
-    const_names! {
+    const_identifiers! {
         PAGE,
         PARENT,
         RESOURCES,
@@ -114,7 +114,7 @@ impl Page {
             writer.write(constants::NL_MARKER),
 
             writer.write(b"<< "),
-            Name::TYPE.write(writer),
+            Identifier::TYPE.write(writer),
             Self::PAGE.write(writer),
             writer.write(constants::NL_MARKER),
 

--- a/pdfgen/src/types/hierarchy/page_tree.rs
+++ b/pdfgen/src/types/hierarchy/page_tree.rs
@@ -1,10 +1,10 @@
 use std::io::{Error, Write};
 
-use pdfgen_macros::const_names;
+use pdfgen_macros::const_identifiers;
 
 use crate::{
     ObjId,
-    types::{constants, hierarchy::primitives::name::Name},
+    types::{constants, hierarchy::primitives::identifier::Identifier},
 };
 
 use super::{
@@ -51,7 +51,7 @@ pub struct PageTree {
 }
 
 impl PageTree {
-    const_names! {
+    const_identifiers! {
         PARENT,
         PAGES,
         MEDIA_BOX,
@@ -106,7 +106,7 @@ impl Object for PageTree {
 
         let written = pdfgen_macros::write_chain! {
             writer.write(b"<< "),
-            Name::TYPE.write(writer),
+            Identifier::TYPE.write(writer),
             Self::PAGES.write(writer),
             writer.write(constants::NL_MARKER),
 

--- a/pdfgen/src/types/hierarchy/primitives/font.rs
+++ b/pdfgen/src/types/hierarchy/primitives/font.rs
@@ -2,11 +2,11 @@
 
 use std::io::{Error, Write};
 
-use pdfgen_macros::const_names;
+use pdfgen_macros::const_identifiers;
 
 use crate::{ObjId, types::constants};
 
-use super::{name::Name, object::Object};
+use super::{identifier::Identifier, object::Object};
 
 /// Represents a font object in a PDF document.
 /// This struct represents a font object in a PDF document, encapsulating the info required to
@@ -19,14 +19,14 @@ pub struct Font {
     pub(crate) id: ObjId<Self>,
 
     /// Specifies the subtype of the font, defining its role or characteristics within the PDF.
-    subtype: Name<Vec<u8>>,
+    subtype: Identifier<Vec<u8>>,
 
     /// Represents the base font type, identifying the general font family or format.
-    base_font: Name<Vec<u8>>,
+    base_font: Identifier<Vec<u8>>,
 }
 
 impl Font {
-    const_names! {
+    const_identifiers! {
         FONT,
         SUBTYPE,
         BASE_FONT,
@@ -38,8 +38,8 @@ impl Font {
         S: Into<Vec<u8>>,
         B: Into<Vec<u8>>,
     {
-        let subtype = Name::new(subtype.into());
-        let base_font = Name::new(base_font.into());
+        let subtype = Identifier::new(subtype.into());
+        let base_font = Identifier::new(base_font.into());
 
         Font {
             id,
@@ -62,7 +62,7 @@ impl Object for Font {
             writer.write(b"<< "),
 
             // /Type /Font
-            Name::TYPE.write(writer),
+            Identifier::TYPE.write(writer),
             Self::FONT.write(writer),
             writer.write(constants::NL_MARKER),
 

--- a/pdfgen/src/types/hierarchy/primitives/identifier.rs
+++ b/pdfgen/src/types/hierarchy/primitives/identifier.rs
@@ -2,10 +2,11 @@
 
 use std::io::{Error, Write};
 
-use pdfgen_macros::const_names;
+use pdfgen_macros::const_identifiers;
 
-/// [`Name`] object is an atomic symbol uniquely defined by a sequence of any characters (8-bit
-/// values) except null (character code 0) that follow these rules:
+/// [`Identifier`] refers to the `Name` object in PDF and it is an atomic symbol uniquely defined
+/// by a sequence of any characters (8-bit values) except null (character code 0) that follow these
+/// rules:
 ///
 /// * A NUMBER SIGN (23h) (#) in a name shall be written by using its 2-digit hexadecimal code
 ///   (23), preceded by the NUMBER SIGN.
@@ -18,14 +19,14 @@ use pdfgen_macros::const_names;
 /// No token delimiter (such as white-space) occurs between the SOLIDUS and the encoded name.
 /// Whitespace used as part of a name shall always be coded using the 2-digit hexadecimal notation.
 #[derive(Debug, Clone)]
-pub(crate) struct Name<T: AsRef<[u8]>> {
+pub(crate) struct Identifier<T: AsRef<[u8]>> {
     inner: T,
 }
 
-pub(crate) type OwnedName = Name<Vec<u8>>;
+pub(crate) type OwnedIdentifier = Identifier<Vec<u8>>;
 
-impl<T: AsRef<[u8]>> Name<T> {
-    /// Creates a new [`Name`] from a value implementing `AsRef<[u8]>`.
+impl<T: AsRef<[u8]>> Identifier<T> {
+    /// Creates a new [`Identifier`] from a value implementing `AsRef<[u8]>`.
     pub fn new(inner: T) -> Self {
         let inner_ref = inner.as_ref();
         if inner_ref.is_empty() {
@@ -39,7 +40,7 @@ impl<T: AsRef<[u8]>> Name<T> {
         Self { inner }
     }
 
-    /// Encode and write this `Name` into the provided implementor of [`Write`].
+    /// Encode and write this [`Identifier`] into the provided implementor of [`Write`].
     pub fn write(&self, writer: &mut dyn Write) -> Result<usize, Error> {
         Ok(pdfgen_macros::write_chain! {
             writer.write(b"/"),
@@ -48,15 +49,15 @@ impl<T: AsRef<[u8]>> Name<T> {
         })
     }
 
-    /// The number of bytes that this `Name` occupies when written into the PDF document. This does
-    /// not include the whitespace written after the `Name`.
+    /// The number of bytes that this [`Identifier`] occupies when written into the PDF document. This does
+    /// not include the whitespace written after the [`Identifier`].
     pub fn len(&self) -> usize {
         self.inner.as_ref().len() + 1
     }
 
-    /// Returns the referenced version to this `Name`.
-    pub fn as_ref(&self) -> Name<&[u8]> {
-        Name {
+    /// Returns the referenced version to this [`Identifier`].
+    pub fn as_ref(&self) -> Identifier<&[u8]> {
+        Identifier {
             inner: self.inner.as_ref(),
         }
     }
@@ -70,15 +71,15 @@ impl<T: AsRef<[u8]>> Name<T> {
     }
 }
 
-impl Name<&'static [u8]> {
-    const_names! {
+impl Identifier<&'static [u8]> {
+    const_identifiers! {
         pub(crate) TYPE,
         pub(crate) X_OBJECT,
         pub(crate) FONT
     }
 
-    /// Create a new [`Name`] from a static byte slice.
-    /// This allows seamless creation of `Name` for static data without specifying lifetimes.
+    /// Create a new [`Identifier`] from a static byte slice.
+    /// This allows seamless creation of [`Identifier`] for static data without specifying lifetimes.
     pub const fn from_static(inner: &'static [u8]) -> Self {
         if inner.is_empty() {
             panic!("Dictionary Key must start with '/' followed by at least one ASCII character.");
@@ -98,12 +99,12 @@ impl Name<&'static [u8]> {
 
 #[cfg(test)]
 mod tests {
-    use super::Name;
+    use super::Identifier;
 
     #[test]
     pub fn new_name_static() {
-        let static_key = Name::from_static(b"StaticKey");
-        const STATIC_KEY: Name<&'static [u8]> = Name::from_static(b"StaticKey");
+        let static_key = Identifier::from_static(b"StaticKey");
+        const STATIC_KEY: Identifier<&'static [u8]> = Identifier::from_static(b"StaticKey");
 
         let mut out_buf = Vec::new();
         static_key.write(&mut out_buf).unwrap();
@@ -116,7 +117,7 @@ mod tests {
 
     #[test]
     pub fn new_name_dynamic() {
-        let dynamic_key = Name::new(Vec::from("DynamicKey"));
+        let dynamic_key = Identifier::new(Vec::from("DynamicKey"));
 
         let mut out_buf = Vec::new();
         dynamic_key.write(&mut out_buf).unwrap();
@@ -125,7 +126,7 @@ mod tests {
 
     #[test]
     pub fn new_name_slice() {
-        let slice_key = Name::new(b"SliceKey".as_ref());
+        let slice_key = Identifier::new(b"SliceKey".as_ref());
 
         let mut out_buf = Vec::new();
         slice_key.write(&mut out_buf).unwrap();

--- a/pdfgen/src/types/hierarchy/primitives/mod.rs
+++ b/pdfgen/src/types/hierarchy/primitives/mod.rs
@@ -3,7 +3,7 @@
 
 pub mod array;
 pub mod font;
-pub mod name;
+pub mod identifier;
 pub mod object;
 pub mod rectangle;
 pub mod resources;

--- a/pdfgen/src/types/hierarchy/primitives/resources.rs
+++ b/pdfgen/src/types/hierarchy/primitives/resources.rs
@@ -6,15 +6,21 @@ use crate::{IdManager, ObjId, types::hierarchy::content::image::Image};
 
 use super::{
     font::Font,
-    name::{Name, OwnedName},
+    identifier::{Identifier, OwnedIdentifier},
 };
 
 /// Represents a single entry in the [`Resources`] dictionary.
 #[derive(Debug)]
 #[non_exhaustive]
 pub(crate) enum ResourceEntry {
-    Image { name: OwnedName, image: Image },
-    Font { name: OwnedName, id: ObjId<Font> },
+    Image {
+        name: OwnedIdentifier,
+        image: Image,
+    },
+    Font {
+        name: OwnedIdentifier,
+        id: ObjId<Font>,
+    },
 }
 
 /// Resource dictionary enumerates the named resources needed by the operators in the content
@@ -31,7 +37,7 @@ pub struct Resources {
 }
 
 impl Resources {
-    /// Creates a new [`OwnedName`] with a given prefix and internally maintained index.
+    /// Creates a new [`OwnedIdentifier`] with a given prefix and internally maintained index.
     ///
     /// # Example
     ///
@@ -40,15 +46,15 @@ impl Resources {
     /// let name = res.create_name("Im");
     /// assert_eq!(name.as_bytes(), b"/Im1 ");
     /// ```
-    fn create_name(&mut self, prefix: &str) -> Name<Vec<u8>> {
+    fn create_name(&mut self, prefix: &str) -> Identifier<Vec<u8>> {
         self.counter += 1;
-        Name::new(format!("{prefix}{}", self.counter).into_bytes())
+        Identifier::new(format!("{prefix}{}", self.counter).into_bytes())
     }
 
     /// Adds a reference to an [`Image`] to this `Resources` dictionary.
     ///
     /// [`Image`]: crate::types::hierarchy::content::image::Image
-    pub(crate) fn add_image(&mut self, image: Image) -> Name<&[u8]> {
+    pub(crate) fn add_image(&mut self, image: Image) -> Identifier<&[u8]> {
         let name = self.create_name("Im");
         let img = ResourceEntry::Image { name, image };
 
@@ -64,7 +70,7 @@ impl Resources {
     /// Adds a reference to a [`Font`] to this `Resources` dictionary.
     ///
     /// [`Font`]: crate::types::hierarchy::primitives::font::Font
-    pub(crate) fn add_font(&mut self, font_id: ObjId<Font>) -> Name<&[u8]> {
+    pub(crate) fn add_font(&mut self, font_id: ObjId<Font>) -> Identifier<&[u8]> {
         let name = self.create_name("F");
         let fnt = ResourceEntry::Font { name, id: font_id };
 
@@ -123,7 +129,7 @@ impl Renderable<'_> {
     pub(crate) fn write_ref(&self, writer: &mut dyn Write) -> std::io::Result<usize> {
         match self.entry {
             ResourceEntry::Image { name, .. } => Ok(pdfgen_macros::write_chain! {
-                Name::X_OBJECT.write(writer),
+                Identifier::X_OBJECT.write(writer),
 
                 writer.write(b"<< "),
                 name.write(writer),
@@ -133,7 +139,7 @@ impl Renderable<'_> {
             }),
 
             ResourceEntry::Font { name, id } => Ok(pdfgen_macros::write_chain! {
-                Name::FONT.write(writer),
+                Identifier::FONT.write(writer),
 
                 writer.write(b"<< "),
                 name.write(writer),

--- a/pdfgen/src/types/hierarchy/trailer.rs
+++ b/pdfgen/src/types/hierarchy/trailer.rs
@@ -2,14 +2,14 @@
 
 use std::io::Write;
 
-use pdfgen_macros::const_names;
+use pdfgen_macros::const_identifiers;
 
 use crate::{ObjId, types::constants};
 
 use super::{
     catalog::Catalog,
     cross_reference_table::CrossReferenceTable,
-    primitives::{array::WriteArray, name::Name},
+    primitives::{array::WriteArray, identifier::Identifier},
 };
 
 /// Extension trait for implementations of Trailer sections (currently only CRT).
@@ -35,7 +35,7 @@ impl WriteTrailer for CrossReferenceTable {
         root: ObjId<Catalog>,
         id: [u8; 16],
     ) -> Result<(), std::io::Error> {
-        const_names! {
+        const_identifiers! {
             SIZE,
             ROOT,
             ID: b"ID",

--- a/pdfgen_macros/src/lib.rs
+++ b/pdfgen_macros/src/lib.rs
@@ -1,12 +1,12 @@
 use proc_macro::TokenStream;
 
-mod name;
+mod identifier;
 mod write_chain;
 
-/// Generate one or more `const Name<&'static [u8]>` values from the given identifiers. Identifiers
-/// should be specified in upper snake case and will be converted to pascal-cased PDF names. All
-/// leters will be replaced with their lowercase equivalents, except the first letter and any
-/// letter preceded by an underscore. For example:
+/// Generate one or more `const Identifier<&'static [u8]>` values from the given identifiers.
+/// Identifiers should be specified in upper snake case and will be converted to pascal-cased PDF
+/// names. All leters will be replaced with their lowercase equivalents, except the first letter
+/// and any letter preceded by an underscore. For example:
 ///
 /// * `IDENT` -> `Ident`
 /// * `SECOND_IDENT` -> `SecondIdent`
@@ -14,22 +14,22 @@ mod write_chain;
 /// # Example
 ///
 /// ```ignore
-/// use pdfgen_macros::const_names;
+/// use pdfgen_macros::const_identifiers;
 ///
 /// pub struct SomeStruct;
 ///
 /// impl SomeStruct {
-///     const_names!(TYPE, SUBTYPE, MEDIA_BOX);
+///     const_identifiers!(TYPE, SUBTYPE, MEDIA_BOX);
 ///
 ///     // expands to
-///     const TYPE: Name<&'static [u8]> = Name::from_static(b"Type");
-///     const SUBTYPE: Name<&'static [u8]> = Name::from_static(b"Subtype");
-///     const MEDIA_BOX: Name<&'static [u8]> = Name::from_static(b"MediaBox");
+///     const TYPE: Identifier<&'static [u8]> = Identifier::from_static(b"Type");
+///     const SUBTYPE: Identifier<&'static [u8]> = Identifier::from_static(b"Subtype");
+///     const MEDIA_BOX: Identifier<&'static [u8]> = Identifier::from_static(b"MediaBox");
 /// }
 /// ```
 #[proc_macro]
-pub fn const_names(token_stream: TokenStream) -> TokenStream {
-    name::const_names(token_stream)
+pub fn const_identifiers(token_stream: TokenStream) -> TokenStream {
+    identifier::const_identifiers(token_stream)
 }
 
 /// Helper macro for counting the number of written bytes in multiple consecutive writes, where


### PR DESCRIPTION
### What?
Renames the `Name` to `Identifier` (and all references to `Name`).

### Why?
Some keys in dictionary can literally be `Name`, so you could have a `Name` with a value `Name`. This is very confusing. Instead, we're going with the more standard name (pun not intended) for these kinds of values - Identifier. 

### Notes
`pdfgen_macros::const_names` is also renamed to `pdfgen_macros::const_identifiers`.

### Checklist
- [x] Tests are added/updated.
- [x] Documentation is added/updated.
- [x] Self-review of code changes completed.

### Related Issues
Closes #64 
