### PR TITLE
feat: implement `Text` superscript and subscript support

### DIFF
--- a/pdfgen/src/types/hierarchy/content/text.rs
+++ b/pdfgen/src/types/hierarchy/content/text.rs
@@ -4,7 +4,9 @@ use std::io::{self, Write};
 
 use crate::types::{
     constants,
-    hierarchy::primitives::{identifier::Identifier, rectangle::Position, string::PdfString},
+    hierarchy::primitives::{
+        identifier::Identifier, rectangle::Position, string::PdfString, unit::Unit,
+    },
 };
 
 use super::color::Color;
@@ -163,6 +165,44 @@ impl TextBuilder<true> {
     /// Creates the [`Text`] object from the already provided configurations.
     pub fn build(self) -> Text {
         self.inner
+    }
+
+    /// Comment
+    fn build_with_shift(&self, shift: f32, scale: f32) -> Text {
+        // yposition is shifted by a percentage (shift multiplier) of the user unit font size
+        let ypos = Unit::from_unit(
+            self.inner.transform.position.y.into_user_unit()
+                + (self.inner.transform.size as f32 * shift),
+        );
+
+        let transform = TextTransform {
+            position: Position {
+                x: self.inner.transform.position.x,
+                y: ypos,
+            },
+            // size is scaled down by the [scale] multiplier of it's original value
+            size: (self.inner.transform.size as f32 * scale).round() as u32,
+        };
+
+        Text {
+            content: self.inner.content.clone(),
+            transform,
+            color: self.inner.color,
+        }
+    }
+
+    /// Comment
+    pub fn build_superscript(&self) -> Text {
+        // yposition is shifted up ~35% of the user space unit font size
+        // size is scaled down to ~65% of it's original value
+        self.build_with_shift(0.35, 0.65)
+    }
+
+    /// Comment
+    pub fn build_subscript(self) -> Text {
+        // yposition is shifted down ~35% of the user space unit font size
+        // size is scaled down to ~65% of it's original value
+        self.build_with_shift(-0.35, 0.65)
     }
 }
 

--- a/pdfgen/src/types/hierarchy/content/text.rs
+++ b/pdfgen/src/types/hierarchy/content/text.rs
@@ -167,8 +167,9 @@ impl TextBuilder<true> {
         self.inner
     }
 
-    /// Comment
-    fn build_with_shift(mut self, shift: f32, scale: f32) -> Text {
+    /// Creates the shifted/scaled [`Text`] object from the already provided configurations,
+    /// transforming the text to either superscript or subscript.
+    fn build_transformed(mut self, shift: f32, scale: f32) -> Text {
         // yposition is shifted by a percentage (shift multiplier) of the user unit font size
         self.inner.transform.position.y = Unit::from_unit(
             self.inner.transform.position.y.into_user_unit()
@@ -181,18 +182,18 @@ impl TextBuilder<true> {
         self.inner
     }
 
-    /// Comment
+    /// Creates the superscript [`Text`] object from the already provided configurations.
     pub fn build_superscript(self) -> Text {
         // yposition is shifted up ~35% of the user space unit font size
         // size is scaled down to ~65% of it's original value
-        self.build_with_shift(0.35, 0.65)
+        self.build_transformed(0.35, 0.65)
     }
 
-    /// Comment
+    /// Creates the subscript [`Text`] object from the already provided configurations.
     pub fn build_subscript(self) -> Text {
         // yposition is shifted down ~35% of the user space unit font size
         // size is scaled down to ~65% of it's original value
-        self.build_with_shift(-0.35, 0.65)
+        self.build_transformed(-0.35, 0.65)
     }
 }
 

--- a/pdfgen/src/types/hierarchy/content/text.rs
+++ b/pdfgen/src/types/hierarchy/content/text.rs
@@ -199,7 +199,7 @@ impl TextBuilder<true> {
     }
 
     /// Comment
-    pub fn build_subscript(self) -> Text {
+    pub fn build_subscript(&self) -> Text {
         // yposition is shifted down ~35% of the user space unit font size
         // size is scaled down to ~65% of it's original value
         self.build_with_shift(-0.35, 0.65)
@@ -253,5 +253,91 @@ mod tests {
         (This is a custom text content.) Tj
         ET
         ");
+    }
+
+    #[test]
+    pub fn superscript_text() {
+        let txt_builder = Text::builder()
+            .with_content("This is")
+            .with_expanded_content(" a superscript text content.")
+            .with_size(14)
+            .at(Position::from_mm(0.0, 0.0));
+
+        let superscript_text1 = txt_builder
+            .build_subscript()
+            .to_bytes(Identifier::from_static(b"CustomFnt"))
+            .unwrap();
+
+        let superscript_text2 = txt_builder
+            .build_subscript()
+            .to_bytes(Identifier::from_static(b"CustomFnt"))
+            .unwrap();
+
+        let output1 = String::from_utf8_lossy(&superscript_text1);
+        insta::assert_snapshot!(output1, @r"
+        BT
+        /DeviceRGB cs
+        0 0 0 sc
+        /CustomFnt 9 Tf
+        0 -4.9 Td
+        (This is a superscript text content.) Tj
+        ET
+        ");
+
+        let output2 = String::from_utf8_lossy(&superscript_text2);
+        insta::assert_snapshot!(output2, @r"
+        BT
+        /DeviceRGB cs
+        0 0 0 sc
+        /CustomFnt 9 Tf
+        0 -4.9 Td
+        (This is a superscript text content.) Tj
+        ET
+        ");
+
+        assert_eq!(output1, output2);
+    }
+
+    #[test]
+    pub fn subscript_text() {
+        let txt_builder = Text::builder()
+            .with_content("This is")
+            .with_expanded_content(" a subscript text content.")
+            .with_size(14)
+            .at(Position::from_mm(0.0, 0.0));
+
+        let subscript_text1 = txt_builder
+            .build_subscript()
+            .to_bytes(Identifier::from_static(b"CustomFnt"))
+            .unwrap();
+
+        let subscript_text2 = txt_builder
+            .build_subscript()
+            .to_bytes(Identifier::from_static(b"CustomFnt"))
+            .unwrap();
+
+        let output1 = String::from_utf8_lossy(&subscript_text1);
+        insta::assert_snapshot!(output1, @r"
+        BT
+        /DeviceRGB cs
+        0 0 0 sc
+        /CustomFnt 9 Tf
+        0 -4.9 Td
+        (This is a subscript text content.) Tj
+        ET
+        ");
+
+        let output2 = String::from_utf8_lossy(&subscript_text2);
+        insta::assert_snapshot!(output2, @r"
+        BT
+        /DeviceRGB cs
+        0 0 0 sc
+        /CustomFnt 9 Tf
+        0 -4.9 Td
+        (This is a subscript text content.) Tj
+        ET
+        ");
+
+        assert_eq!(output1, output2);
     }
 }

--- a/pdfgen/src/types/hierarchy/content/text.rs
+++ b/pdfgen/src/types/hierarchy/content/text.rs
@@ -119,6 +119,18 @@ impl Text {
     }
 }
 
+/// Comment
+enum Script {
+    /// Comment
+    Normal,
+
+    /// Comment
+    Super,
+
+    /// Comment
+    Sub,
+}
+
 /// A builder for constructing a [`Text`] object, allowing incremental modifications.
 /// The `IS_INIT` const generic tracks whether initialization has been completed (if position has
 /// been set).
@@ -126,6 +138,9 @@ impl Text {
 pub struct TextBuilder<const IS_INIT: bool> {
     /// The underlying [`Text`] object being built.
     inner: Text,
+
+    /// Comment
+    script: Script,
 }
 
 impl<const IS_INIT: bool> TextBuilder<IS_INIT> {
@@ -133,7 +148,10 @@ impl<const IS_INIT: bool> TextBuilder<IS_INIT> {
     /// object is allowed.
     pub fn at(mut self, pos: Position) -> TextBuilder<true> {
         self.inner.transform.position = pos;
-        TextBuilder { inner: self.inner }
+        TextBuilder {
+            inner: self.inner,
+            script: Script::Normal,
+        }
     }
 
     /// Sets the content of the [`Text`].
@@ -159,14 +177,21 @@ impl<const IS_INIT: bool> TextBuilder<IS_INIT> {
         self.inner.color = color;
         self
     }
+
+    /// Comment
+    pub fn superscript(mut self) -> Self {
+        self.script = Script::Super;
+        self
+    }
+
+    /// Comment
+    pub fn subscript(mut self) -> Self {
+        self.script = Script::Sub;
+        self
+    }
 }
 
 impl TextBuilder<true> {
-    /// Creates the [`Text`] object from the already provided configurations.
-    pub fn build(self) -> Text {
-        self.inner
-    }
-
     /// Creates the shifted/scaled [`Text`] object from the already provided configurations,
     /// transforming the text to either superscript or subscript.
     fn build_transformed(mut self, shift: f32, scale: f32) -> Text {
@@ -182,18 +207,13 @@ impl TextBuilder<true> {
         self.inner
     }
 
-    /// Creates the superscript [`Text`] object from the already provided configurations.
-    pub fn build_superscript(self) -> Text {
-        // yposition is shifted up ~35% of the user space unit font size
-        // size is scaled down to ~65% of it's original value
-        self.build_transformed(0.35, 0.65)
-    }
-
-    /// Creates the subscript [`Text`] object from the already provided configurations.
-    pub fn build_subscript(self) -> Text {
-        // yposition is shifted down ~35% of the user space unit font size
-        // size is scaled down to ~65% of it's original value
-        self.build_transformed(-0.35, 0.65)
+    /// Creates the [`Text`] object from the already provided configurations.
+    pub fn build(self) -> Text {
+        match self.script {
+            Script::Normal => self.inner,
+            Script::Super => self.build_transformed(0.35, 0.65),
+            Script::Sub => self.build_transformed(-0.35, 0.65),
+        }
     }
 }
 

--- a/pdfgen/src/types/hierarchy/content/text.rs
+++ b/pdfgen/src/types/hierarchy/content/text.rs
@@ -168,38 +168,28 @@ impl TextBuilder<true> {
     }
 
     /// Comment
-    fn build_with_shift(&self, shift: f32, scale: f32) -> Text {
+    fn build_with_shift(mut self, shift: f32, scale: f32) -> Text {
         // yposition is shifted by a percentage (shift multiplier) of the user unit font size
-        let ypos = Unit::from_unit(
+        self.inner.transform.position.y = Unit::from_unit(
             self.inner.transform.position.y.into_user_unit()
                 + (self.inner.transform.size as f32 * shift),
         );
 
-        let transform = TextTransform {
-            position: Position {
-                x: self.inner.transform.position.x,
-                y: ypos,
-            },
-            // size is scaled down by the [scale] multiplier of it's original value
-            size: (self.inner.transform.size as f32 * scale).round() as u32,
-        };
+        // size is scaled down by the [scale] multiplier of it's original value
+        self.inner.transform.size = (self.inner.transform.size as f32 * scale).round() as u32;
 
-        Text {
-            content: self.inner.content.clone(),
-            transform,
-            color: self.inner.color,
-        }
+        self.inner
     }
 
     /// Comment
-    pub fn build_superscript(&self) -> Text {
+    pub fn build_superscript(self) -> Text {
         // yposition is shifted up ~35% of the user space unit font size
         // size is scaled down to ~65% of it's original value
         self.build_with_shift(0.35, 0.65)
     }
 
     /// Comment
-    pub fn build_subscript(&self) -> Text {
+    pub fn build_subscript(self) -> Text {
         // yposition is shifted down ~35% of the user space unit font size
         // size is scaled down to ~65% of it's original value
         self.build_with_shift(-0.35, 0.65)
@@ -257,24 +247,17 @@ mod tests {
 
     #[test]
     pub fn superscript_text() {
-        let txt_builder = Text::builder()
+        let superscript_text = Text::builder()
             .with_content("This is")
             .with_expanded_content(" a superscript text content.")
             .with_size(14)
-            .at(Position::from_mm(0.0, 0.0));
-
-        let superscript_text1 = txt_builder
-            .build_subscript()
+            .at(Position::from_mm(0.0, 0.0))
+            .build_superscript()
             .to_bytes(Identifier::from_static(b"CustomFnt"))
             .unwrap();
 
-        let superscript_text2 = txt_builder
-            .build_subscript()
-            .to_bytes(Identifier::from_static(b"CustomFnt"))
-            .unwrap();
-
-        let output1 = String::from_utf8_lossy(&superscript_text1);
-        insta::assert_snapshot!(output1, @r"
+        let output = String::from_utf8_lossy(&superscript_text);
+        insta::assert_snapshot!(output, @r"
         BT
         /DeviceRGB cs
         0 0 0 sc
@@ -283,61 +266,28 @@ mod tests {
         (This is a superscript text content.) Tj
         ET
         ");
-
-        let output2 = String::from_utf8_lossy(&superscript_text2);
-        insta::assert_snapshot!(output2, @r"
-        BT
-        /DeviceRGB cs
-        0 0 0 sc
-        /CustomFnt 9 Tf
-        0 -4.9 Td
-        (This is a superscript text content.) Tj
-        ET
-        ");
-
-        assert_eq!(output1, output2);
     }
 
     #[test]
     pub fn subscript_text() {
-        let txt_builder = Text::builder()
+        let subscript_text = Text::builder()
             .with_content("This is")
-            .with_expanded_content(" a subscript text content.")
+            .with_expanded_content(" a superscript text content.")
             .with_size(14)
-            .at(Position::from_mm(0.0, 0.0));
-
-        let subscript_text1 = txt_builder
+            .at(Position::from_mm(0.0, 0.0))
             .build_subscript()
             .to_bytes(Identifier::from_static(b"CustomFnt"))
             .unwrap();
 
-        let subscript_text2 = txt_builder
-            .build_subscript()
-            .to_bytes(Identifier::from_static(b"CustomFnt"))
-            .unwrap();
-
-        let output1 = String::from_utf8_lossy(&subscript_text1);
-        insta::assert_snapshot!(output1, @r"
+        let output = String::from_utf8_lossy(&subscript_text);
+        insta::assert_snapshot!(output, @r"
         BT
         /DeviceRGB cs
         0 0 0 sc
         /CustomFnt 9 Tf
         0 -4.9 Td
-        (This is a subscript text content.) Tj
+        (This is a superscript text content.) Tj
         ET
         ");
-
-        let output2 = String::from_utf8_lossy(&subscript_text2);
-        insta::assert_snapshot!(output2, @r"
-        BT
-        /DeviceRGB cs
-        0 0 0 sc
-        /CustomFnt 9 Tf
-        0 -4.9 Td
-        (This is a subscript text content.) Tj
-        ET
-        ");
-
-        assert_eq!(output1, output2);
     }
 }

--- a/pdfgen/src/types/hierarchy/content/text.rs
+++ b/pdfgen/src/types/hierarchy/content/text.rs
@@ -262,7 +262,7 @@ mod tests {
         /DeviceRGB cs
         0 0 0 sc
         /CustomFnt 9 Tf
-        0 -4.9 Td
+        0 4.9 Td
         (This is a superscript text content.) Tj
         ET
         ");

--- a/pdfgen/src/types/hierarchy/content/text.rs
+++ b/pdfgen/src/types/hierarchy/content/text.rs
@@ -70,7 +70,10 @@ impl Text {
             },
         };
 
-        TextBuilder { inner: txt }
+        TextBuilder {
+            inner: txt,
+            script: Script::Normal,
+        }
     }
 
     /// Expands the inner content with the provided one.
@@ -120,6 +123,7 @@ impl Text {
 }
 
 /// Comment
+#[derive(Debug, Clone)]
 enum Script {
     /// Comment
     Normal,
@@ -273,7 +277,8 @@ mod tests {
             .with_expanded_content(" a superscript text content.")
             .with_size(14)
             .at(Position::from_mm(0.0, 0.0))
-            .build_superscript()
+            .superscript()
+            .build()
             .to_bytes(Identifier::from_static(b"CustomFnt"))
             .unwrap();
 
@@ -296,7 +301,8 @@ mod tests {
             .with_expanded_content(" a superscript text content.")
             .with_size(14)
             .at(Position::from_mm(0.0, 0.0))
-            .build_subscript()
+            .subscript()
+            .build()
             .to_bytes(Identifier::from_static(b"CustomFnt"))
             .unwrap();
 

--- a/pdfgen/src/types/hierarchy/content/text.rs
+++ b/pdfgen/src/types/hierarchy/content/text.rs
@@ -122,16 +122,16 @@ impl Text {
     }
 }
 
-/// Comment
+/// Represents the script mode of text in a PDF object.
 #[derive(Debug, Clone)]
 enum Script {
-    /// Comment
+    /// Standard text, rendered at the baseline.
     Normal,
 
-    /// Comment
+    /// Superscript text, raised above the baseline.
     Super,
 
-    /// Comment
+    /// Subscript text, lowered below the baseline.
     Sub,
 }
 
@@ -143,7 +143,7 @@ pub struct TextBuilder<const IS_INIT: bool> {
     /// The underlying [`Text`] object being built.
     inner: Text,
 
-    /// Comment
+    /// Represents the script type of the [`Text`] object being built.
     script: Script,
 }
 
@@ -182,13 +182,13 @@ impl<const IS_INIT: bool> TextBuilder<IS_INIT> {
         self
     }
 
-    /// Comment
+    /// Sets the script mode of the [`Text`] to superscript.
     pub fn superscript(mut self) -> Self {
         self.script = Script::Super;
         self
     }
 
-    /// Comment
+    /// Sets the script mode of the [`Text`] to subscript.
     pub fn subscript(mut self) -> Self {
         self.script = Script::Sub;
         self

--- a/pdfgen/src/types/hierarchy/primitives/resources.rs
+++ b/pdfgen/src/types/hierarchy/primitives/resources.rs
@@ -125,7 +125,7 @@ impl Resources {
         })
     }
 
-    pub(crate) fn renderables(&self, id_manager: &mut IdManager) -> Vec<Renderable> {
+    pub(crate) fn renderables(&self, id_manager: &mut IdManager) -> Vec<Renderable<'_>> {
         self.entries
             .iter()
             .map(|entry| Renderable {

--- a/pdfgen/tests/gen_test.rs
+++ b/pdfgen/tests/gen_test.rs
@@ -298,7 +298,8 @@ fn page_superscript_subscript_text() {
             Rectangle::A4.width().into_user_unit() / 2.,
             Rectangle::A4.height().into_user_unit() / 2.,
         ))
-        .build_superscript();
+        .superscript()
+        .build();
 
     page.add_text(superscript_text, font_id.clone());
 
@@ -320,7 +321,8 @@ fn page_superscript_subscript_text() {
             Rectangle::A4.width().into_user_unit() / 2. + 100.,
             Rectangle::A4.height().into_user_unit() / 2. - 200.,
         ))
-        .build_subscript();
+        .subscript()
+        .build();
 
     page.add_text(subcript_text, font_id.clone());
 

--- a/pdfgen/tests/gen_test.rs
+++ b/pdfgen/tests/gen_test.rs
@@ -271,3 +271,58 @@ fn multi_color_space_text() {
 
     macros::snap_test!(document);
 }
+
+#[test]
+fn page_superscript_subscript_text() {
+    let mut document = Document::builder().with_page_size(Rectangle::A4).build();
+
+    let font_id = document.create_font("Type1".into(), "Helvetica".into());
+    let page = document.create_page();
+
+    let first_text = Text::builder()
+        .with_content("Hello, ")
+        .with_expanded_content("here's a fun formula for you: E=m*c")
+        .with_size(14)
+        .at(Position::from_units(
+            Rectangle::A4.width().into_user_unit() / 2. - 260.,
+            Rectangle::A4.height().into_user_unit() / 2.,
+        ))
+        .build();
+
+    page.add_text(first_text, font_id.clone());
+
+    let superscript_text = Text::builder()
+        .with_content("2")
+        .with_size(14)
+        .at(Position::from_units(
+            Rectangle::A4.width().into_user_unit() / 2.,
+            Rectangle::A4.height().into_user_unit() / 2.,
+        ))
+        .build_superscript();
+
+    page.add_text(superscript_text, font_id.clone());
+
+    let second_text = Text::builder()
+        .with_content("How about chemical notation for carbon dioxide, ykyk: CO")
+        .with_size(14)
+        .at(Position::from_units(
+            Rectangle::A4.width().into_user_unit() / 2. - 260.,
+            Rectangle::A4.height().into_user_unit() / 2. - 200.,
+        ))
+        .build();
+
+    page.add_text(second_text, font_id.clone());
+
+    let subcript_text = Text::builder()
+        .with_content("2")
+        .with_size(14)
+        .at(Position::from_units(
+            Rectangle::A4.width().into_user_unit() / 2. + 100.,
+            Rectangle::A4.height().into_user_unit() / 2. - 200.,
+        ))
+        .build_subscript();
+
+    page.add_text(subcript_text, font_id.clone());
+
+    macros::snap_test!(document);
+}

--- a/pdfgen/tests/snapshots/gen_test/page_superscript_subscript_text.pdf
+++ b/pdfgen/tests/snapshots/gen_test/page_superscript_subscript_text.pdf
@@ -1,0 +1,85 @@
+%PDF-2.0
+1 0 obj
+<< /Type /Catalog 
+/Pages 2 0 R >>
+endobj
+
+2 0 obj
+<< /Type /Pages 
+/MediaBox [0 0 592.441 839.0551]
+/Kids [4 0 R]
+/Count 1 >>
+endobj
+
+4 0 obj
+<< /Type /Page 
+/Parent 2 0 R
+/Resources << /Font << /F1 3 0 R /F2 3 0 R /F3 3 0 R /F4 3 0 R  >> >>
+/Contents 5 0 R
+>>
+endobj
+
+
+5 0 obj
+<< /Length 366 >>
+stream
+BT
+/DeviceRGB cs
+0 0 0 sc
+/F1 14 Tf
+36.22049 419.52756 Td
+(Hello, here's a fun formula for you: E=m*c) Tj
+ET
+BT
+/DeviceRGB cs
+0 0 0 sc
+/F2 9 Tf
+296.2205 424.42755 Td
+(2) Tj
+ET
+BT
+/DeviceRGB cs
+0 0 0 sc
+/F3 14 Tf
+36.22049 219.52756 Td
+(How about chemical notation for carbon dioxide, ykyk: CO) Tj
+ET
+BT
+/DeviceRGB cs
+0 0 0 sc
+/F4 9 Tf
+396.2205 214.62756 Td
+(2) Tj
+ET
+
+endstream
+endobj
+
+3 0 obj
+<< /Type /Font 
+/Subtype /Type1 
+/BaseFont /Helvetica 
+>>
+endobj
+
+xref
+0 9
+0000000010 00000 n 
+0000000061 00000 n 
+0000000153 00000 n 
+0000000288 00000 n 
+0000000288 00000 n 
+0000000288 00000 n 
+0000000288 00000 n 
+0000000289 00000 n 
+0000000707 00000 n 
+trailer
+       << /Size 9
+       /Root 1 0 R
+       /ID [<f20d7556fbf637a9422abc7c7c750fbb>
+          <f20d7556fbf637a9422abc7c7c750fbb>
+          ]
+       >>
+startxref
+781
+%%EOF


### PR DESCRIPTION
### What?
This PR implements the support for `Text` object creation as either superscript or subscript.

### Why?
To further expand our pdfgen supported features.

### How?
By introducing functions inside the `TextBuilder` which serve the purpose to scale and shift the text positioning in order to make it superscript/subscript.

### Notes
N/A

### Checklist
- [x] Tests are added/updated.
- [x] Documentation is added/updated.
- [x] Self-review of code changes completed.

### Related Issues
Closes #38 
