### PR TITLE
fix: correct publishing issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [workspace.dependencies]
+pdfgen_macros = { path = "pdfgen_macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,3 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-pdfgen_macros = { path = "pdfgen_macros" }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add `pdfgen` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pdfgen = "0.3.0"
+pdfgen = "0.3.1"
 ```
 
 ---

--- a/pdfgen/Cargo.toml
+++ b/pdfgen/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+readme = "README.md"
 
 [dependencies]
 md5 = "0.7.0"

--- a/pdfgen/Cargo.toml
+++ b/pdfgen/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 md5 = "0.7.0"
 hex = "0.4.3"
 image = "0.25.5"
-pdfgen_macros = {path = "../pdfgen_macros"}
+pdfgen_macros = { version = "0.1.0", path = "../pdfgen_macros" }
 thiserror = "2.0.12"
 
 [dev-dependencies]

--- a/pdfgen/Cargo.toml
+++ b/pdfgen/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
-readme = "README.md"
 
 [dependencies]
 md5 = "0.7.0"

--- a/pdfgen/Cargo.toml
+++ b/pdfgen/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 md5 = "0.7.0"
 hex = "0.4.3"
 image = "0.25.5"
-pdfgen_macros = { version = "0.1.0", path = "../pdfgen_macros" }
+pdfgen_macros = { workspace = true }
 thiserror = "2.0.12"
 
 [dev-dependencies]

--- a/pdfgen/Cargo.toml
+++ b/pdfgen/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 md5 = "0.7.0"
 hex = "0.4.3"
 image = "0.25.5"
-pdfgen_macros = { workspace = true }
+pdfgen_macros = { version = "0.1.0", path = "../pdfgen_macros" }
 thiserror = "2.0.12"
 
 [dev-dependencies]

--- a/pdfgen/README.md
+++ b/pdfgen/README.md
@@ -34,7 +34,7 @@ Add `pdfgen` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pdfgen = "0.3.0"
+pdfgen = "0.3.1"
 ```
 
 ---

--- a/pdfgen/README.md
+++ b/pdfgen/README.md
@@ -1,0 +1,153 @@
+## pdfgen
+
+**pdfgen** is a low-level PDF rendering crate that handles the core structure and internals of PDF generation. It focuses on providing precise control over catalogs, page trees, objects, references, and other essential components of PDF files.  
+**pdfgen** is the foundation crate for our higher-level pediferrous crate: it provides precise control over PDF structure, as well as content authoring (text, fonts, colors, images). It manages catalogs, page trees, cross-reference tables, trailers, and object references — all the building blocks for generating PDF files programmatically.
+
+This crate is ideal for developers who need fine-grained control or want to build higher-level abstractions like the upcoming **pediferrous** crate.
+
+### Key Features
+
+- **Core PDF Structure Management**: Automatically handles critical PDF components, including:
+  - Catalogs
+  - Page Trees
+  - Object References
+  - Cross-Reference Tables (CRT)
+  - Trailers
+- **Flexible Page creation**
+  - Create pages with standard or custom dimensions (`A4`, `A5`, ..., custom `Rectangle`)  
+- **Content authoring**
+  - Content stream objects  
+  - UTF-8 text strings  
+  - Font support (start with standard Type1 fonts)  
+  - Text objects with positioning & sizing  
+  - Superscript and subscript text  
+  - Color management (Gray, RGB, CMYK with conversion helpers)  
+  - Raster image embedding (position, scaling)  
+- **Streamlined output**
+  - Write fully compliant PDF files to any `Write` implementation
+
+---
+
+### Getting Started
+
+Add `pdfgen` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+pdfgen = "0.3.0"
+```
+
+---
+
+### Example: full usage
+
+```rust
+use std::{fs::File, path::PathBuf, io::Result};
+
+use pdfgen::{
+    Document,
+    types::hierarchy::{
+        content::{
+            color::{CmykValue, Color},
+            image::Image,
+            text::Text,
+        },
+        primitives::{
+            rectangle::{Position, Rectangle},
+            unit::Unit,
+        },
+    },
+};
+
+fn main() -> Result<()> {
+    // Create document with A4 page size
+    let mut document = Document::builder().with_page_size(Rectangle::A4).build();
+
+    // Register a standard font
+    let font_id = document.create_font("Type1".into(), "Helvetica".into());
+
+    // Create a page
+    let page = document.create_page();
+
+    // --- Create a color ---
+    let red = Color::Rgb {
+        red: 255,
+        green: 0,
+        blue: 0,
+    };
+
+    // --- Add a colored text ---
+    let colored_text = Text::builder()
+        .with_content("Hello ")
+        .with_expanded_content("from colorful pdfgen!")
+        .with_size(14)
+        .at(Position::from_units(
+            Rectangle::A4.width().into_user_unit() / 2. - 260.,
+            Rectangle::A4.height().into_user_unit() / 2. + 200.,
+        ))
+        .with_color(red)
+        .build();
+
+    page.add_text(colored_text, font_id.clone());
+
+    // --- Add superscript & subscript texts ---
+    let presuperscript_text = Text::builder()
+        .with_content("Hello, here's a fun formula for you: E=m*c")
+        .with_size(14)
+        .at(Position::from_units(
+            Rectangle::A4.width().into_user_unit() / 2. - 260.,
+            Rectangle::A4.height().into_user_unit() / 2.,
+        ))
+        .build();
+
+    page.add_text(presuperscript_text, font_id.clone());
+
+    let superscript_text = Text::builder()
+        .with_content("2")
+        .with_size(14)
+        .at(Position::from_units(
+            Rectangle::A4.width().into_user_unit() / 2.,
+            Rectangle::A4.height().into_user_unit() / 2.,
+        ))
+        .superscript()
+        .build();
+
+    page.add_text(superscript_text, font_id.clone());
+
+    let presubscript_text = Text::builder()
+        .with_content("How about chemical notation for carbon dioxide, ykyk: CO")
+        .with_size(14)
+        .at(Position::from_units(
+            Rectangle::A4.width().into_user_unit() / 2. - 260.,
+            Rectangle::A4.height().into_user_unit() / 2. - 200.,
+        ))
+        .build();
+
+    page.add_text(presubscript_text, font_id.clone());
+
+    let subcript_text = Text::builder()
+        .with_content("2")
+        .with_size(14)
+        .at(Position::from_units(
+            Rectangle::A4.width().into_user_unit() / 2. + 100.,
+            Rectangle::A4.height().into_user_unit() / 2. - 200.,
+        ))
+        .subscript()
+        .build();
+
+    page.add_text(subcript_text, font_id.clone());
+
+    // --- Add an image ---
+    let img = Image::from_file(&File::open(PathBuf::from("sample_image.jpg")).unwrap())
+        .at(Position::from_units(50., 50.))
+        .scaled(Position::from_units(100., 100.))
+        .build();
+
+    page.add_image(img);
+
+    // --- Write document to file ---
+    let mut file = File::create("output.pdf")?;
+    doc.write(&mut file)?;
+    Ok(())
+}
+```

--- a/pdfgen_macros/Cargo.toml
+++ b/pdfgen_macros/Cargo.toml
@@ -2,18 +2,16 @@
 name = "pdfgen_macros"
 version = "0.1.0"
 description = "Holding macros used across PDFGen."
-edition.workspace = true 
+edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+readme = "../README.md"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0", features = ["parsing"] }
-quote = "1.0"
-proc-macro2 = "1.0"
-
-[dev-dependencies]
-syn = { version = "2.0", features = ["parsing", "extra-traits"] }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/pdfgen_macros/Cargo.toml
+++ b/pdfgen_macros/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
-readme = "../README.md"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
### What?
This PR will make `pdfgen_macros` publishable and correct `pdfgen` dependency.

### Why?
To enable crates.io support for both `pdfgen` and `pdfgen_macros`.

### Related Issues
Closes #75 